### PR TITLE
Adds coercion of parameter values again

### DIFF
--- a/src/yada/coerce.clj
+++ b/src/yada/coerce.clj
@@ -91,6 +91,7 @@
      from numbers on the JVM (without losing precision)"
   [schema]
   (or
+   (coercion-matcher schema)
    (kw-map-matcher schema)
    (multiple-args-matcher schema)))
 


### PR DESCRIPTION
Parameter coercion (e.g. query parameter values) should be working again now.