### PR TITLE
GetResult now accepts a fn as response Closes #23

### DIFF
--- a/src/yada/methods.clj
+++ b/src/yada/methods.clj
@@ -125,7 +125,12 @@
   (interpret-get-result [_ ctx]
     (d/error-deferred (ex-info "" {:status 404}))
 
-    #_(throw (ex-info "" {:status 404}))))
+    #_(throw (ex-info "" {:status 404})))
+  clojure.lang.Fn
+  (interpret-get-result [f ctx]
+    (interpret-get-result (f ctx) ctx))
+
+  )
 
 (deftype GetMethod [])
 


### PR DESCRIPTION
It follows the same way as PostResult to avoid this problem