### PR TITLE
Allow for header schema verification and coercion

### DIFF
--- a/src/yada/core.clj
+++ b/src/yada/core.clj
@@ -197,8 +197,8 @@
 
            :header
            (when-let [schema (get-in parameters [method :header])]
-             (let [params (select-keys (-> request :headers) (keys schema))]
-               (rs/coerce schema params :query)))})]
+             (let [params (-> request :headers)]
+               (rs/coerce (assoc schema String String) params :query)))})]
 
     (let [errors (filter (comp schema.utils/error? second) parameters)]
       (if (not-empty errors)


### PR DESCRIPTION
Specifying a :header schema didn't work as intended

1. Specifying keywords (mandatory) resulted in required value not found because header keys are parsed as strings
2. Specifying (s/optional-key ...) or (s/required-key ...) is not compatible with select-keys

e.g. 

```clojure
{:header {(s/optional-key "x-user-id") s/Uuid}}
```

The solution works partially:

1. It coerces values properly
2. It allows for additional headers and they will be parsed to a String value (as before)

It does not:

1. Coerce keys. They will remain Strings.

