### PR TITLE
Allow for body coercion to a binary format (e.g. java.io.InputStream)

### DIFF
--- a/src/yada/body.clj
+++ b/src/yada/body.clj
@@ -38,13 +38,13 @@
   ([body media-type encoding schema]
    (rs/coerce schema (coerce-request-body body media-type encoding) :json))
   ([body media-type encoding]
-   (json/decode (bs/convert body String {:encoding encoding}) keyword)))
+    (when body (json/decode (bs/convert body String {:encoding encoding}) keyword))))
 
 (defmethod coerce-request-body "application/octet-stream"
   [body media-type encoding schema]
   (cond
-    (instance? String schema) (bs/convert body String {:encoding encoding})
-    :otherwise (bs/convert body String {:encoding encoding})))
+    (instance? String schema) (when body (bs/convert body String {:encoding encoding}))
+    :otherwise (when body (bs/convert body String {:encoding encoding}))))
 
 (defmethod coerce-request-body nil
   [body media-type schema] nil)
@@ -53,7 +53,7 @@
   ([body media-type encoding schema]
    (rs/coerce schema (coerce-request-body body media-type encoding) :query))
   ([body media-type encoding]
-   (keywordize-keys (codec/form-decode (bs/convert body String {:encoding encoding})))))
+   (keywordize-keys (codec/form-decode (when body (bs/convert body String {:encoding encoding}))))))
 
 (defprotocol MessageBody
   (to-body [resource representation] "Construct the reponse body for the given resource, given the negotiated representation (metadata)")

--- a/src/yada/core.clj
+++ b/src/yada/core.clj
@@ -188,12 +188,13 @@
 
            :body
            (when-let [schema (get-in parameters [method :body])]
-             (let [body (read-body (-> ctx :request))]
+             (let [body (-> ctx :request :body)]
                (body/coerce-request-body
-                body
-                ;; See rfc7231#section-3.1.1.5 - we should assume application/octet-stream
-                (or (req/content-type request) "application/octet-stream")
-                schema)))
+                 body
+                 ;; See rfc7231#section-3.1.1.5 - we should assume application/octet-stream
+                 (or (req/content-type request) "application/octet-stream")
+                 (or (req/character-encoding request) "UTF-8")
+                 schema)))
 
            :header
            (when-let [schema (get-in parameters [method :header])]


### PR DESCRIPTION
yada would always convert the body to a String by using yada.body/read-body. However, when uploading images e.g. just the binary representation is needed.

This change moves the String conversion with the appropriate encoding to the multimethod ```coerce-request-body``` which can then decide for a proper conversion on the media-type instead of always assuming String conversion.