### PR TITLE
adding support for coercing edn from the request body

### DIFF
--- a/src/yada/body.clj
+++ b/src/yada/body.clj
@@ -18,7 +18,8 @@
    [schema.core :as s]
    [yada.charset :as charset]
    [yada.journal :as journal]
-   [yada.media-type :as mt])
+   [yada.media-type :as mt]
+   [clojure.edn :as edn])
   (:import
    [clojure.core.async.impl.channels ManyToManyChannel]
    [java.io File]
@@ -54,6 +55,12 @@
    (rs/coerce schema (coerce-request-body body media-type) :query))
   ([body media-type]
    (keywordize-keys (codec/form-decode body))))
+
+(defmethod coerce-request-body "application/edn"
+  ([representation media-type schema]
+    (rs/coerce schema (coerce-request-body representation media-type) :edn))
+  ([representation _]
+    (edn/read-string representation)))
 
 (defprotocol MessageBody
   (to-body [resource representation] "Construct the reponse body for the given resource, given the negotiated representation (metadata)")

--- a/test/yada/coerce_request_body_test.clj
+++ b/test/yada/coerce_request_body_test.clj
@@ -1,0 +1,32 @@
+(ns yada.coerce-request-body-test
+  (:require [clojure.test :refer :all]
+            [yada.body :refer [coerce-request-body]]
+            [schema.core :refer [defschema] :as s]))
+
+(defschema TestSchema
+  {:a s/Str
+   :b s/Int})
+
+(deftest coerce-request-body-test
+
+  (testing "coercing application/json"
+    (is (= {:a "Hello" :b 123}
+           (coerce-request-body
+             "{\"a\": \"Hello\", \"b\": 123}"
+             "application/json"
+             TestSchema)))
+    (is (= [1 2 3]
+           (coerce-request-body
+             "[1, 2, 3]"
+             "application/json"))))
+
+  (testing "coercing application/edn"
+    (is (= {:a "Hello" :b 123}
+           (coerce-request-body
+             "{:a \"Hello\" :b 123}"
+             "application/edn"
+             TestSchema)))
+    (is (= [1 2 3]
+           (coerce-request-body
+             "[1 2 3]"
+             "application/edn")))))


### PR DESCRIPTION
I couldn't find any tests for coerce-request-body so I also added a few for json and obviously edn.