### PR TITLE
adding support for application/transit+json formatting both ways

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,8 @@
    [ring-basic-authentication "1.0.5"]
    [org.clojure/core.async "0.1.346.0-17112a-alpha"]
    [org.clojure/tools.reader "0.9.1"]
-   [org.clojars.ikoblik/clj-index "0.0.2"]]
+   [org.clojars.ikoblik/clj-index "0.0.2"]
+   [com.cognitect/transit-clj "0.8.285"]]
 
   :pedantic? :abort
 

--- a/test/yada/transit_json_test.clj
+++ b/test/yada/transit_json_test.clj
@@ -1,0 +1,72 @@
+(ns yada.transit-json-test
+  (:require [clojure.test :refer :all]
+            [schema.core :as s]
+            [yada.body :as sut]))
+
+(s/defschema TestSchema
+  {:a s/Str
+   :b s/Keyword
+   :c [s/Int]})
+
+(def ^:private test-map {:a "Hello" :b :foo :c [4 5 6]})
+
+(defmacro is-coercing-correctly?
+  ([expected value content-type schema]
+   `(is (= ~expected
+           (sut/coerce-request-body ~value ~content-type ~schema))))
+  ([expected value content-type]
+   `(is (= ~expected
+           (sut/coerce-request-body ~value ~content-type)))))
+
+(deftest reading-transit-json-from-body
+  (let [content-type "application/transit+json"
+        json "[\"^ \",\"~:a\",\"Hello\",\"~:b\",\"~:foo\",\"~:c\",[4,5,6]]"
+        json-verbose "{\"~:a\":\"Hello\",\"~:b\":\"~:foo\",\"~:c\":[4,5,6]}"]
+    (testing (str "coercing " content-type)
+      (is-coercing-correctly? test-map json content-type)
+      (is-coercing-correctly? test-map json content-type TestSchema)
+      (is-coercing-correctly? test-map json-verbose content-type)
+      (is-coercing-correctly? test-map json-verbose content-type TestSchema))))
+
+(deftest rendering-to-transit-json
+  (let [basic {:media-type {:name       "application/transit+json"
+                            :parameters {"pretty" false}}}
+        pretty (assoc-in basic [:media-type :parameters "pretty"] true)
+        
+        test-map {:a "Hello" :b :foo :c [4 5 6]}
+        map-json "[\"^ \",\"~:a\",\"Hello\",\"~:b\",\"~:foo\",\"~:c\",[4,5,6]]"
+        map-json-verbose "{\"~:a\":\"Hello\",\"~:b\":\"~:foo\",\"~:c\":[4,5,6]}"]
+
+    (testing "render-map"
+      (is (= map-json
+             (sut/render-map test-map basic)))
+
+      (is (= map-json-verbose
+             (sut/render-map test-map pretty))))
+
+    (testing "render-seq"
+      (is (= "[4,5,6]"
+             (sut/render-seq [4 5 6] basic)
+             (sut/render-seq [4 5 6] pretty))))
+
+    (testing "render-error"
+      (is (= {:status  503
+              :message "Service Unavailable"
+              :id      12345
+              :error   {:some :error-happened}}
+
+             (sut/render-error 503
+                               {:some :error-happened}
+                               basic
+                               {:id 12345})
+
+             (sut/render-error 503
+                               {:some :error-happened}
+                               pretty
+                               {:id 12345})
+
+             (sut/render-error 503
+                               {:some :error-happened}
+                               (assoc-in basic [:media-type :name] "application/json")
+                               {:id 12345}))))
+    ))


### PR DESCRIPTION
> Transit is a format and set of libraries for conveying values between applications written in different programming languages.
> - https://github.com/cognitect/transit-format

I have implemented support for ```application/transit+json``` in the following places:
- ```yada.body/coerce-request-body```
- ```yada.body/render-map```
- ```yada.body/render-seq```
- ```yada.body/render-error```

I haven't added support for ```application/transit+msgpack``` because it seems yada doesn't support binary content types at the moment.

Added a few tests as well to exercise conversion back and forth. ```yada.body/render-error``` doesn't seem to be doing any formatting for json and edn so I just copied their behavior for transit+json.

The change introduces a new dependency though: ```[com.cognitect/transit-clj "0.8.285"]```. I hope that's not a problem given that it's fairly standard.