### PR TITLE
Fix AOT compilation

### DIFF
--- a/src/yada/body.clj
+++ b/src/yada/body.clj
@@ -2,6 +2,7 @@
 
 (ns yada.body
   (:require
+   [clojure.core.async]
    [clojure.java.io :as io]
    [clojure.pprint :refer [pprint]]
    [clojure.tools.logging :refer :all]
@@ -12,6 +13,7 @@
    [hiccup.page :refer [html5]]
    [json-html.core :as jh]
    [manifold.stream :refer [->source transform]]
+   [manifold.stream.async]
    [ring.util.codec :as codec]
    [ring.util.http-status :refer [status]]
    [schema.core :as s]


### PR DESCRIPTION
When using yada as a dependency in an AOT-compiled project, compilation fails with:

```
java.lang.ClassNotFoundException: clojure.core.async.impl.channels.ManyToManyChannel, compiling:(body.clj:3:1)
Exception in thread "main" java.lang.ClassNotFoundException: clojure.core.async.impl.channels.ManyToManyChannel, compiling:(body.clj:3:1)
...
```

Explicitly requiring `[clojure.core.async]` then fails with:

```
java.lang.ClassNotFoundException: manifold.stream.async.CoreAsyncSource, compiling:(body.clj:3:1)
Exception in thread "main" java.lang.ClassNotFoundException: manifold.stream.async.CoreAsyncSource, compiling:(body.clj:3:1)
...
```

AOT compilation finally succeeds if `[manifold.stream.async]` (also used in the `yada.body` import) is additionally required.