### PR TITLE
Fix typo in user-manual.md

### DIFF
--- a/dev/resources/user-manual.md
+++ b/dev/resources/user-manual.md
@@ -33,7 +33,7 @@ a contributor!
 
 [Back to index](/)
 
-## Forward
+## Foreword
 
 State is everywhere. The world is moving and we need to keep up. We need
 our computers to help us stay up-to-date with the latest information,


### PR DESCRIPTION
Is this a typo? It's hard to tell! Forward doesn't make _much_ sense except on a "we're moving forward!", but foreword would as the preface to the document?