### PR TITLE
Include sequences for body coercions

### DIFF
--- a/src/yada/body.clj
+++ b/src/yada/body.clj
@@ -78,6 +78,10 @@
   clojure.lang.APersistentVector
   (to-body [v representation]
     (encode-message (render-seq v representation) representation))
+  
+  clojure.lang.ASeq
+  (to-body [v representation]
+    (encode-message (render-seq v representation) representation))
 
   File
   (to-body [f _]


### PR DESCRIPTION
Fixes an issue where `'("foo" "bar")` would render as `"foobar"` instead of `["foo", "bar"]` for JSON (and other things that should be coerced to.