### PR TITLE
New classpath resource

### DIFF
--- a/src/yada/resources/classpath_resource.clj
+++ b/src/yada/resources/classpath_resource.clj
@@ -1,0 +1,48 @@
+(ns yada.resources.classpath-resource
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [yada.resource :refer [resource]]
+   [yada.protocols :refer [as-resource]]))
+
+(defn new-classpath-resource
+  "Create a new classpath resource that resolves requests with
+   path info in the active classpath, relative to root-path.
+
+   Optionally takes an options map with the following keys:
+
+   * index-files - a collection of files to try if the path info
+                   ends with /
+
+   Example:
+
+      (new-classpath-resource \"public\")
+
+   would resolve index.html to public/index.html inside
+   the active classpath (e.g. of the JAR that serves the resource).
+
+   If used with bidi, the following route
+
+     [\"\" (yada (new-classpath-resource
+                \"public\" {:index-files [\"index.html\"]}))]
+
+   can be used to serve all files in public/ and fall back to
+   index.html for URL paths like / or foo/."
+  ([root-path]
+   (new-classpath-resource root-path nil))
+  ([root-path {:keys [index-files]}]
+   (resource
+    {:path-info?   true
+     :methods      {}
+     :sub-resource
+     (fn [ctx]
+       (let [path-info (-> ctx :request :path-info)
+             path      (str/replace path-info #"^/" "")
+             files     (if (= (last path-info) \/)
+                         (map #(io/file root-path path %) index-files)
+                         (list (io/file root-path path)))
+             res       (first (sequence (comp (map #(.getPath %))
+                                              (map io/resource)
+                                              (drop-while nil?))
+                                        files))]
+         (as-resource res)))})))

--- a/src/yada/resources/jar_resource.clj
+++ b/src/yada/resources/jar_resource.clj
@@ -1,6 +1,6 @@
 ;; Copyright © 2015, JUXT LTD.
 
-(ns yada.resources.classpath-resource
+(ns yada.resources.jar-resource
   (:require
    [clojure.java.io :as io]
    [ring.util.mime-type :refer (ext-mime-type)]
@@ -8,7 +8,7 @@
    [yada.protocols :refer [as-resource]])
   (:import [java.util.jar JarFile]))
 
-(defn new-classpath-resource [prefix]
+(defn new-jar-resource [prefix]
   (resource
    {:path-info? true
     :methods {}

--- a/src/yada/resources/url_resource.clj
+++ b/src/yada/resources/url_resource.clj
@@ -26,7 +26,8 @@
       :methods
       {:get
        {:produces
-        [{:media-type #{(ext-mime-type (.getPath url))}
+        [{:media-type #{(or (ext-mime-type (.getPath url))
+                            "application/octet-stream")}
           :charset charset/platform-charsets
           }]
         :response


### PR DESCRIPTION
This is a first pass of writing a new classpath resource. I have left a few comments in the source code and commit messages. Note: I tried to write tests for the source but the classpath of `lein test` includes local file system paths and those will be different on every machine. This resource is mostly useful when running jars or uberjars.