### PR TITLE
adding schema.coerce json coercion matchers to json process-request-body

### DIFF
--- a/test/yada/process_request_body_test.clj
+++ b/test/yada/process_request_body_test.clj
@@ -49,6 +49,22 @@
     (is (= {:foo "bar"}
            (get-in (process {:foo s/Str}
                             (json/encode {:foo "bar"})
+                            ) [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process {:foo s/Keyword}
+                            (json/encode {:foo :yoyo})
+                            ) [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process {:foo clojure.lang.Keyword}
+                            (json/encode {:foo :yoyo})
+                            ) [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process {:foo (s/eq :yoyo)}
+                            (json/encode {:foo :yoyo})
+                            ) [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process {:foo (s/enum :yoyo :bar)}
+                            (json/encode {:foo :yoyo})
                             ) [:parameters :body]))))
   (testing "sad path"
     (is (thrown? clojure.lang.ExceptionInfo


### PR DESCRIPTION
I noticed that when using json as the incoming content type, keyword values (not keys) were blowing up with 400. There are some built-in json coercion matchers in schema.coerce that help solve this but they weren't being used in yada so I added them.