### PR TITLE
add information about bidi dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ yada requires the following :-
 - a Java JDK/JRE installation, version 8 or above
 - Clojure 1.7.0
 - Aleph 0.4.1-beta3 or above (provided via a dependency)
+- bidi 2.0.0 or above
 
 ## Running documentation and examples offline
 


### PR DESCRIPTION
Add information about the dependency to `bidi` since it is required in the source, and handlers were introduced in bidi 2

https://github.com/juxt/yada/blob/fbff7d294a65d3c66a9d78d090cdfb5bdb108396/src/yada/handler.clj#L7