### PR TITLE
Swagger tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /pom.xml
 /pom.xml.asc
 /.lein-repl-history
+/.idea/
+/*.iml
 /todo.org
 /notes.org
 /dev/resources/hello-async.png

--- a/test/yada/swagger_test.clj
+++ b/test/yada/swagger_test.clj
@@ -3,7 +3,7 @@
 (ns yada.swagger-test
   (:require [yada.swagger :refer :all]
             [clojure.test :refer :all]
-            [yada.yada :refer [as-resource]]
+            [yada.yada :refer [as-resource yada resource]]
             [yada.schema :as ys]
             [clojure.set :as set]
             [schema.core :as s]
@@ -13,6 +13,111 @@
 
 ;; TODO: Build a proper swagger_test suite
 
+(deftest test-routes->ring-swagger-spec
+  (testing "simple"
+    (is (= {:info  {:version "2.0"
+                    :title   "My API"}
+            :paths {"" {:get {:produces ["text/plain"]}}}}
+           (routes->ring-swagger-spec
+             ["" (yada "test")]
+             {:info {:version "2.0"
+                     :title   "My API"}})))
+    (is (= {:paths {"/api" {:get {:parameters {:formData {:q String}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:methods {:get {:parameters {:form {:q String}}
+                                                :response   (fn [_] nil)}}})])))
+    (is (= {:paths {"/api" {:get  {:description "Get the right data"
+                                   :summary     "Get"
+                                   :produces    ["text/html"]
+                                   :consumes    ["text/plain"]
+                                   :parameters  {:query {:q String}}}
+                            :post {:summary    "POST item"
+                                   :parameters {:formData {:name String}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:methods {:get  {:description "Get the right data"
+                                                 :summary     "Get"
+                                                 :produces    "text/html;pretty=true"
+                                                 :consumes    "text/plain"
+                                                 :parameters  {:query {:q String}}
+                                                 :response    (fn [_] nil)}
+                                          :post {:summary    "POST item"
+                                                 :parameters {:form {:name String}}
+                                                 :response   (constantly nil)}}})]))))
+
+
+  (testing "resource & method merge"
+    (is (= {:paths {"/api" {:get {:produces ["text/html" "text/xml" "text/plain"]}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:produces ["text/html" "text/xml"]
+                                :methods  {:get {:produces ["text/html" "text/html;pretty=true" "text/plain"]
+                                                 :response (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:consumes ["text/html" "text/xml" "text/plain"]}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:consumes ["text/html" "text/xml"]
+                                :methods  {:get {:consumes ["text/html" "text/html;pretty=true" "text/plain"]
+                                                 :response (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:produces ["text/html" "text/xml"]
+                                  :consumes ["text/html" "text/plain"]}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:produces ["text/html" "text/xml"]
+                                :methods  {:get {:consumes ["text/html" "text/html;pretty=true" "text/plain"]
+                                                 :response (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:consumes ["text/html" "text/xml"]
+                                  :produces ["text/html" "text/plain"]}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:consumes ["text/html" "text/xml"]
+                                :methods  {:get {:produces ["text/html" "text/html;pretty=true" "text/plain"]
+                                                 :response (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:parameters {:path {:id String}
+                                               :query {:id Long}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:parameters {:path {:id String}}
+                                :methods {:get {:parameters {:query {:id Long}}
+                                                :response (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:parameters {:path {:id String
+                                                      :age Long}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:parameters {:path {:id String}}
+                                :methods {:get {:parameters {:path {:age Long}}
+                                                :response (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:parameters {:path {:id Long}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:parameters {:path {:id String}}
+                                :methods {:get {:parameters {:path {:id Long}}
+                                                :response (constantly nil)}}})])))
+    (let [pattern-1 #"[a-zA-Z]*"
+          pattern-2 #"[a-zA-Z0-9]+"]
+      (is (= {:paths {"/api" {:get {:parameters {:path     {:id      String
+                                                            :user_id Long
+                                                            :format  String}
+                                                 :query    {:color    s/Keyword
+                                                            :filter   Long
+                                                            :includes pattern-1}
+                                                 :header   {:token pattern-2
+                                                            :dairy #{:milk :cheese}
+                                                            :ext   [String]}
+                                                 :body     Long
+                                                 :formData {:t_id Long}}}}}}
+             (routes->ring-swagger-spec
+               ["/api" (resource {:parameters {:path   {:id      String
+                                                        :user_id String}
+                                               :query  {:color  s/Keyword
+                                                        :filter String}
+                                               :cookie {:session Long
+                                                        :time    Long}
+                                               :header {:token pattern-2
+                                                        :dairy #{:milk :cream}}}
+                                  :methods    {:get {:parameters {:body   Long
+                                                                  :form   {:t_id Long}
+                                                                  :path   {:user_id Long
+                                                                           :format  String}
+                                                                  :query  {:filter   Long
+                                                                           :includes pattern-1}
+                                                                  :cookie {:session   String
+                                                                           :privilege String}
+                                                                  :header {:dairy #{:milk :cheese}
+                                                                           :ext   [String]}}
+                                                     :response   (constantly nil)}}})]))))))
 
 #_(select-keys
  (get-in (as-resource "Hello World!") [:methods :get])


### PR DESCRIPTION
I have added tests for swagger spec output and removed cookie parameters from swagger output since swagger doesn't support those.

I have also changed the ```swagger-spec``` method by moving the part that generates the input for ring-swagger into its own method called ```routes->ring-swagger-spec``` and that method is what my tests check. I did this because I assume that ring-swagger works correctly when given the right input and I didn't want the test to include the whole schema to swagger thing that ring-swagger does.