### PR TITLE
Add path parameters from bidi to swagger output

### DIFF
--- a/test/yada/swagger_test.clj
+++ b/test/yada/swagger_test.clj
@@ -9,9 +9,25 @@
             [schema.core :as s]
             [schema.coerce :as sc]
             [ring.swagger.swagger2 :as rsw]
-            [ring.swagger.swagger2-schema :as rsws]))
+            [ring.swagger.swagger2-schema :as rsws]
+            [bidi.bidi :as bidi]
+            [clojure.walk :refer [postwalk]])
+  (:import (java.util.regex Pattern)
+           (clojure.lang Keyword)))
 
 ;; TODO: Build a proper swagger_test suite
+
+(defn replace-pattern
+  "regex Pattern instances with the same pattern are not equal so this helper replaces any regex
+  in form that has the same pattern as the argument with the argument so that we can compare with ="
+  [pattern form]
+  (postwalk
+    (fn [item]
+      (if (and (instance? Pattern item)
+               (= (.pattern item) (.pattern pattern)))
+        pattern
+        item))
+    form))
 
 (deftest test-routes->ring-swagger-spec
   (testing "simple"
@@ -68,23 +84,23 @@
              ["/api" (resource {:consumes ["text/html" "text/xml"]
                                 :methods  {:get {:produces ["text/html" "text/html;pretty=true" "text/plain"]
                                                  :response (constantly nil)}}})])))
-    (is (= {:paths {"/api" {:get {:parameters {:path {:id String}
+    (is (= {:paths {"/api" {:get {:parameters {:path  {:id String}
                                                :query {:id Long}}}}}}
            (routes->ring-swagger-spec
              ["/api" (resource {:parameters {:path {:id String}}
-                                :methods {:get {:parameters {:query {:id Long}}
-                                                :response (constantly nil)}}})])))
-    (is (= {:paths {"/api" {:get {:parameters {:path {:id String
+                                :methods    {:get {:parameters {:query {:id Long}}
+                                                   :response   (constantly nil)}}})])))
+    (is (= {:paths {"/api" {:get {:parameters {:path {:id  String
                                                       :age Long}}}}}}
            (routes->ring-swagger-spec
              ["/api" (resource {:parameters {:path {:id String}}
-                                :methods {:get {:parameters {:path {:age Long}}
-                                                :response (constantly nil)}}})])))
+                                :methods    {:get {:parameters {:path {:age Long}}
+                                                   :response   (constantly nil)}}})])))
     (is (= {:paths {"/api" {:get {:parameters {:path {:id Long}}}}}}
            (routes->ring-swagger-spec
              ["/api" (resource {:parameters {:path {:id String}}
-                                :methods {:get {:parameters {:path {:id Long}}
-                                                :response (constantly nil)}}})])))
+                                :methods    {:get {:parameters {:path {:id Long}}
+                                                   :response   (constantly nil)}}})])))
     (let [pattern-1 #"[a-zA-Z]*"
           pattern-2 #"[a-zA-Z0-9]+"]
       (is (= {:paths {"/api" {:get {:parameters {:path     {:id      String
@@ -117,7 +133,53 @@
                                                                            :privilege String}
                                                                   :header {:dairy #{:milk :cheese}
                                                                            :ext   [String]}}
-                                                     :response   (constantly nil)}}})]))))))
+                                                     :response   (constantly nil)}}})])))))
+  (testing "route path parameters"
+    (is (= {:paths {"/api/{id}" {:get {:produces   ["text/plain"]
+                                       :parameters {:path {:id String}}}}}}
+           (routes->ring-swagger-spec [["/api/" :id] (yada "test")])))
+    (let [pattern #"[A-Za-z]+[A-Za-z0-9\*\+\!\-\_\?\.]*(?:%2F[A-Za-z]+[A-Za-z0-9\*\+\!\-\_\?\.]*)?"]
+      (is (= {:paths {"/api/{id}" {:get {:produces   ["text/plain"]
+                                         :parameters {:path {:id pattern}}}}}}
+             (replace-pattern pattern
+                              (routes->ring-swagger-spec [["/api/" [keyword :id]] (yada "test")])))))
+    (is (= {:paths {"/api/{id}" {:get {:produces   ["text/plain"]
+                                       :parameters {:path {:id Long}}}}}}
+           (routes->ring-swagger-spec [["/api/" [long :id]] (yada "test")])))
+    (let [pattern #"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"]
+      (is (= {:paths {"/api/{id}" {:get {:produces   ["text/plain"]
+                                         :parameters {:path {:id pattern}}}}}}
+             (replace-pattern pattern
+                              (routes->ring-swagger-spec [["/api/" [bidi/uuid :id]] (yada "test")])))))
+    (let [pattern #".+\@.+\..+"]
+      (is (= {:paths {"/api/{email}" {:get {:produces   ["text/plain"]
+                                            :parameters {:path {:email pattern}}}}}}
+             (routes->ring-swagger-spec [["/api/" [pattern :email]] (yada "test")]))))
+    (testing "resource or method path parameters replace"
+      (is (= {:paths {"/api/{id}" {:get {:parameters {:path  {:id String}
+                                                      :query {:name Long}}}}}}
+             (routes->ring-swagger-spec
+               [["/api/" :id] (resource {:methods {:get {:parameters {:query {:name Long}}
+                                                         :response   (constantly nil)}}})])))
+      (is (= {:paths {"/api/{id}" {:get {:parameters {:path  {:id String}
+                                                      :query {:name Long}}}}}}
+             (routes->ring-swagger-spec
+               [["/api/" :id] (resource {:parameters {:query {:name Long}}
+                                         :methods    {:get {:response (constantly nil)}}})])))
+      (is (= {:paths {"/api/{id}" {:get {:parameters {:path {:time String}}}}}}
+             (routes->ring-swagger-spec
+               [["/api/" [long :id]] (resource {:methods {:get {:parameters {:path {:time String}}
+                                                                :response   (constantly nil)}}})])))
+      (is (= {:paths {"/api/{id}" {:get {:parameters {:path {:name String}}}}}}
+             (routes->ring-swagger-spec
+               [["/api/" [long :id]] (resource {:parameters {:path {:name String}}
+                                                :methods    {:get {:response (constantly nil)}}})])))
+      (is (= {:paths {"/api/{id}" {:get {:parameters {:path {:name String
+                                                             :time String}}}}}}
+             (routes->ring-swagger-spec
+               [["/api/" [long :id]] (resource {:parameters {:path {:name String}}
+                                                :methods    {:get {:parameters {:path {:time String}}
+                                                                   :response   (constantly nil)}}})]))))))
 
 #_(select-keys
  (get-in (as-resource "Hello World!") [:methods :get])


### PR DESCRIPTION
When the bidi route had path parameters but those parameters where not defined in the resource the swagger output would have the path parameter shown in the url but would be missing the definition for the parameter. Similarly when the bidi route had qualifiers for the path parameters you couldn't even generate the swagger output. This commit fixes these issues so the swagger ouput now reflects what yada actually does when handling a request.

When no path parameters are defined for a resource yada will simply forward the path parameters from bidi directly with no check or coercion. Meaning that bidi does all the type checking and coercion and this commit will include the bidi path parameters with types in the swagger output.

But when a resource does have path parameters defined these must cover all path parameters and so overwrites whatever bidi has specified for the parameters.

Fixes #41