### PR TITLE
Support schema key in query parameters

### DIFF
--- a/src/yada/coerce.clj
+++ b/src/yada/coerce.clj
@@ -72,7 +72,8 @@
   (if (instance? clojure.lang.APersistentMap schema)
     (let [fns (into {}
                     (for [k (keys schema)]
-                      [(to-key k) (to-fn k)]))]
+                      (if (satisfies? ParameterKey k)
+                        [(to-key k) (to-fn k)])))]
       (fn [x]
         (if (map? x)
           (->> x

--- a/test/yada/parameters_test.clj
+++ b/test/yada/parameters_test.clj
@@ -2,10 +2,12 @@
 
 (ns yada.parameters-test
   (:require
-   [clojure.test :refer :all]
-   [schema.core :as s]
-   [yada.interceptors :as i]
-   [yada.resource :as r]))
+    [clojure.test :refer :all]
+    [schema.core :as s]
+    [yada.interceptors :as i]
+    [yada.resource :as r]
+    [manifold.deferred :as d])
+  (:import (clojure.lang ExceptionInfo IDeref)))
 
 (deftest header-test []
   (let [resource (r/resource {:parameters {:header {(s/required-key "X-Foo") s/Str
@@ -15,3 +17,112 @@
                                    :request {:headers {"X-Foo" "Bar"}}})]
       (is (= "Bar"
              (get-in ctx [:parameters :header "X-Foo"]) )))))
+
+(defn parse [resource request]
+  (let [ret (i/parse-parameters {:resource (r/resource resource)
+                                 :request request})]
+    (if (instance? IDeref ret)
+      @ret
+      (:parameters ret))))
+
+(deftest query-test
+  (testing "keyword keys"
+    (is (= {:query {:filter 12}}
+           (parse {:parameters {:query {:filter Long}}
+                   :methods    {}}
+                  {:query-string "filter=12"})))
+    (is (= {:query {:filter "12"}}
+           (parse {:parameters {:query {:filter s/Str}}
+                   :methods    {}}
+                  {:query-string "filter=12"})))
+    (is (= {:query {:filter "12"}}
+           (parse {:parameters {:query {:filter                s/Str
+                                        (s/optional-key :test) Long}}
+                   :methods    {}}
+                  {:query-string "filter=12"})))
+    (is (= {:query {:filter "12"
+                    :test   15}}
+           (parse {:parameters {:query {:filter                s/Str
+                                        (s/optional-key :test) Long}}
+                   :methods    {}}
+                  {:query-string "filter=12&test=15"}))))
+  (testing "string keys"
+    (is (= {:query {"filter" 12}}
+           (parse {:parameters {:query {(s/required-key "filter") Long}}
+                   :methods    {}}
+                  {:query-string "filter=12"})))
+    (is (= {:query {"filter" "12"}}
+           (parse {:parameters {:query {(s/required-key "filter") s/Str
+                                        (s/optional-key "test")   Long}}
+                   :methods    {}}
+                  {:query-string "filter=12"})))
+    (is (= {:query {"filter" "12"
+                    "test"   15}}
+           (parse {:parameters {:query {(s/required-key "filter") s/Str
+                                        (s/optional-key "test")   Long}}
+                   :methods    {}}
+                  {:query-string "filter=12&test=15"}))))
+  (is (thrown? ExceptionInfo
+               (parse {:parameters {:query {:filter Long}}
+                       :methods    {}}
+                      {:query-string "filter=test"})))
+  (testing "schema key"
+    (is (= {:query {:filter          "test"
+                    :order-direction :asc}}
+           (parse {:parameters {:query {:filter          s/Str
+                                        :order-direction (s/enum :asc :desc)
+                                        s/Keyword        Long}}
+                   :methods    {}}
+                  {:query-string "filter=test&order-direction=asc"})))
+    (is (= {:query {:filter          "test"
+                    :order-direction :asc
+                    "age"            "25"}}
+           (parse {:parameters {:query {:filter          s/Str
+                                        :order-direction (s/enum :asc :desc)
+                                        s/Any            s/Any}}
+                   :methods    {}}
+                  {:query-string "filter=test&order-direction=asc&age=25"})))
+    (is (= {:query {:filter          "test"
+                    :order-direction :asc}}
+           (parse {:parameters {:query {:filter                           s/Str
+                                        (s/optional-key :order-direction) (s/enum :asc :desc)
+                                        s/Keyword                         Long}}
+                   :methods    {}}
+                  {:query-string "filter=test&order-direction=asc"})))
+    (is (= {:query {:filter          "test"
+                    :order-direction :asc
+                    :age             12}}
+           (parse {:parameters {:query {:filter                           s/Str
+                                        (s/optional-key :order-direction) (s/enum :asc :desc)
+                                        s/Keyword                         Long}}
+                   :methods    {}}
+                  {:query-string "filter=test&order-direction=asc&age=12"})))
+    (is (= {:query {:filter "test"
+                    :age    12}}
+           (parse {:parameters {:query {:filter                           s/Str
+                                        (s/optional-key :order-direction) (s/enum :asc :desc)
+                                        s/Keyword                         Long}}
+                   :methods    {}}
+                  {:query-string "filter=test&age=12"})))
+    (is (= {:query {14      12
+                    17      88
+                    :filter "test"}}
+           (parse {:parameters {:query {:filter s/Str
+                                        Long    Long}}
+                   :methods    {}}
+                  {:query-string "14=12&filter=test&17=88"})))
+    (is (= {:query {:filter "test"}}
+           (parse {:parameters {:query {:filter s/Str
+                                        Long    Long}}
+                   :methods    {}}
+                  {:query-string "filter=test"})))
+    (is (thrown? ExceptionInfo
+                 (parse {:parameters {:query {:filter s/Str
+                                              Long    Long}}
+                         :methods    {}}
+                        {:query-string "14=12"})))
+    (is (thrown? ExceptionInfo
+                 (parse {:parameters {:query {:filter s/Str
+                                              Long    Long}}
+                         :methods    {}}
+                        {:query-string "filter=test&muh=12"})))))


### PR DESCRIPTION
This adds support for having a schema as a key in resource query
parameters definition. This means that query parameters now support
defining some required and optional query parameters and then specifing
a schema that all other parameters must match.

I have also added more test cases for parse-parameters.

Fixes: #76