### PR TITLE
Support wildcard in responses schema and disallow duplicates

### DIFF
--- a/test/yada/statii_test.clj
+++ b/test/yada/statii_test.clj
@@ -15,5 +15,6 @@
     (testing "wildcard"
       (is (= :c (get* m 405)))))
   (testing "nil"
-    (is (nil? (get {400 :a} 401)))))
+    (is (nil? (get* {400 :a} 401))))
+  (is (= :a (get* {400 :a #{400 401} :b} 400))))
 


### PR DESCRIPTION
While wildcard was allowed in ```get*``` the schema for responses didn't
allow it and so you couldn't use it.

There were also some corner cases in responses where the same status
could be in the key of several responses making it ambigous which
response was the correct one. So I have added a check to the schema
that requires that the keys are disjoint and so unambigous.