### PR TITLE
Custom coercion matchers in resource definitions

### DIFF
--- a/src/yada/multipart.clj
+++ b/src/yada/multipart.clj
@@ -632,10 +632,14 @@
              ;; In Swagger 2.0 you can't have both form and body
              ;; parameters, which seems reasonable
              (or (:form schemas) (:body schemas))
-             (let [coercer (sc/coercer
+             (let [coercion-matchers (get-in ctx [:resource :methods (:method ctx)
+                                                  :coercion-matchers])
+                   matcher (or (:form coercion-matchers) (:body coercion-matchers))
+                   coercer (sc/coercer
                             (or (:form schemas) (:body schemas))
                             (fn [schema]
                               (or
+                               (when matcher (matcher schema))
                                (coerce/+parameter-key-coercions+ schema)
                                ((part-coercion-matcher part-consumer) schema)
                                ((rsc/coercer :json) schema))))

--- a/src/yada/schema.clj
+++ b/src/yada/schema.clj
@@ -196,6 +196,13 @@ convenience of terse, expressive short-hand descriptions."}
   body payload chunks"
   {(s/optional-key :consumer) (s/=> Context Context s/Any)})
 
+(s/defschema MethodParametersCoercionMatchers
+  "A map of coercion matchers as required by `schema.coerce/coercer`."
+  {(s/optional-key :coercion-matchers) {(s/optional-key :path) (s/=> s/Any s/Any)
+                                        (s/optional-key :query) (s/=> s/Any s/Any) 
+                                        (s/optional-key :body) (s/=> s/Any s/Any)
+                                        (s/optional-key :form) (s/=> s/Any s/Any)}})
+
 (def Realm s/Str)
 
 (s/defschema Restriction
@@ -212,6 +219,7 @@ convenience of terse, expressive short-hand descriptions."}
 (s/defschema Method
   (merge Response
          MethodParameters
+         MethodParametersCoercionMatchers
          Produces
          Consumes
          Consumer


### PR DESCRIPTION
(as discussed with @mccraigmccraig)

There was no way of coercing incoming data to fit the schemas
supplied under :parameters key in resource definitions.

- optional :coercion-matchers keyword can now be added to each
  method specification. The value should be a map of  keywords
  to matchers (as per `schema.coerce/coercer`).

Example

  {:methods {:post {:parameters {:body {:user s/Str
                                        :created-at s/Inst}
                    :coercion-matchers {:body {s/Inst inst/read-instant-date}}}}}}

Things to consider:
- this change does not introduce coercion support for header params (see yada.interceptors/parse-parameters)
- I'm still not convinced about the exact placement of the :coercion-matchers map
- the supplied matcher is 'or'-ed with the hard-coded ones, which seems to me would be 
  the most common case.