### PR TITLE
invoke custom error handling for all requests

### DIFF
--- a/src/yada/handler.clj
+++ b/src/yada/handler.clj
@@ -118,7 +118,7 @@
        (apply d/chain ctx (:interceptor-chain ctx))
 
        (d/catch
-           clojure.lang.ExceptionInfo
+           java.lang.Exception
            (fn [e]
              (error-handler e)
              (let [data (error-data e)]

--- a/test/yada/custom_error_response_test.clj
+++ b/test/yada/custom_error_response_test.clj
@@ -1,0 +1,58 @@
+(ns yada.custom-error-response-test
+  (:require [clojure.test :refer :all]
+            [byte-streams :as b]
+            [ring.mock.request :refer [request]]
+            [yada.yada :refer [yada handler resource]]))
+
+(defn- error-resource
+  [method exception]
+  (resource
+   {:methods
+    {method
+     {:produces "text/plain"
+      :response (fn [ctx] (throw exception))}}
+    :responses
+    {500 {:produces "text/plain"
+          :response (fn [ctx] "Error")}}}))
+
+(deftest custom-error-response-test []
+  (testing "GET custom error for java.lang.Exception"
+    (try
+      (let [handler (yada (error-resource :get (Exception. "Oh!")))
+            response @(handler (request :get "/"))]
+        (is (= 500 (:status response)))
+        (is (= "Error" (b/to-string (:body response)))))
+      (catch Exception e
+        ;; prevent stack trace in error report - just show an actionable message
+        (let [error-handled? (nil? e)]
+          (is error-handled? "java.lang.Exception not caught by handler")))))
+
+  (testing "GET custom error for clojure.lang.ExceptionInfo"
+    (try
+      (let [handler (yada (error-resource :get (ex-info "Oh!" {})))
+            response @(handler (request :get "/"))]
+        (is (= 500 (:status response)))
+        (is (= "Error" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
+
+  (testing "POST custom error for java.lang.Exception"
+    (try
+      (let [handler (yada (error-resource :post (Exception. "Oh!")))
+            response @(handler (request :post "/"))]
+        (is (= 500 (:status response)))
+        (is (= "Error" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "java.lang.Exception not caught by handler")))))
+
+  (testing "POST custom error for clojure.lang.ExceptionInfo"
+    (try
+      (let [handler (yada (error-resource :post (ex-info "Oh!" {})))
+            response @(handler (request :post "/"))]
+        (is (= 500 (:status response)))
+        (is (= "Error" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "clojure.lang.ExceptionInfo not caught by handler"))))))


### PR DESCRIPTION
Re: https://github.com/juxt/yada/issues/55

The `500` entry in the custom responses map was not invoked for `POST` requests:

```clojure
(yada/yada
   (yada/resource
    {:methods
     {:post {:consumes "application/json"
             :produces "text/plain"
             :response (fn [ctx] (throw (Exception. "Oh!")))}}
     :responses
     {500 {:produces "text/plain"
           :response (fn [ctx] "Internal error")}}}))
```

The tests I added work, but generate some spam in the logs. Would appreciate hints on how to reduce the logging here. 

