### PR TITLE
Add webjar resource and used it for swagger-ui

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,9 @@
 
    ;; Provide exclusions libraries
    [com.google.guava/guava "18.0"]
+
+   ;; Webjars resources
+   [org.webjars/webjars-locator "0.27"]
    ]
 
   :pedantic? :abort

--- a/src/yada/resources/webjar_resource.clj
+++ b/src/yada/resources/webjar_resource.clj
@@ -1,0 +1,73 @@
+(ns yada.resources.webjar-resource
+  (:import [org.webjars WebJarAssetLocator])
+  (:require
+    [clojure.java.io :as io]
+    [clojure.string :as str]
+    [yada.resource :refer [resource]]
+    [yada.resources.classpath-resource :refer [new-classpath-resource]]
+    [yada.test :as test]
+    [yada.protocols :refer [as-resource]]))
+
+(def ^:private webjars-pattern
+  #"META-INF/resources/webjars/([^/]+)/([^/]+)/(.*)")
+
+(defn- asset-path [resource]
+  (let [[_ name version path] (re-matches webjars-pattern resource)]
+    path))
+
+(defn- asset-map [^WebJarAssetLocator locator webjar]
+  (->> (.listAssets locator (str webjar "/"))
+       (map (juxt asset-path identity))
+       (into {})))
+
+(defn new-webjar-resource
+  "Create a new webjar resource that resolves requests with
+   path info in the specified webjar name in the active classpath.
+
+   Optionally takes an options map with the following keys:
+
+   * index-files - a collection of files to try if the path info
+                   ends with /
+
+   Example:
+
+      (new-webjar-resource \"swagger-ui\")
+
+   would resolve index.html to META-INF/resources/webjars/swagger-ui//index.html inside
+   the active classpath (e.g. of the JAR that serves the resource).
+
+   If used with bidi, the following route
+
+     [\"\" (yada (new-webjar-resource
+                \"swagger-ui\" {:index-files [\"index.html\"]}))]
+
+   can be used to serve all files for the swagger-ui webjar and fall back to
+   index.html for URL paths like / or foo/."
+  ([webjar]
+   (new-webjar-resource webjar nil))
+  ([webjar {:keys [index-files]}]
+   (resource
+     {:path-info?   true
+      :methods      {}
+      :sub-resource (let [assets (asset-map (WebJarAssetLocator.) webjar)]
+                      (fn [ctx]
+                        (let [path-info (-> ctx :request :path-info)
+                              path (str/replace path-info #"^/" "")
+                              files (if (= (last path-info) \/)
+                                      (map #(get assets (str path %)) index-files)
+                                      (list (get assets path)))
+                              res (first (sequence (comp (map io/resource)
+                                                         (drop-while nil?))
+                                                   files))]
+                          (as-resource res))))})))
+
+(defn webjars-route-pair
+  ""
+  ([] (webjars-route-pair nil))
+  ([options]
+   (let [webjars (->> (WebJarAssetLocator.)
+                      .getWebJars
+                      keys
+                      (map (juxt identity #(new-webjar-resource % options))))]
+     ["" webjars])))
+

--- a/src/yada/swagger.clj
+++ b/src/yada/swagger.clj
@@ -24,7 +24,7 @@
    [yada.media-type :as mt]
    [yada.protocols :as p]
    [yada.resource :refer [resource]]
-   [yada.resources.classpath-resource :refer [new-classpath-resource]]
+   [yada.resources.webjar-resource :refer [new-webjar-resource]]
    [yada.schema :as ys]
    [yada.util :refer [md5-hash] :as util])
   (:import [clojure.lang PersistentVector Keyword Fn]
@@ -222,7 +222,7 @@
     (map->Swaggered
      {:spec spec
       :routes routes
-      :swagger-ui (handler (new-classpath-resource "META-INF/resources/webjars/swagger-ui/2.1.3"))
+      :swagger-ui (handler (new-webjar-resource "swagger-ui"))
       :spec-handlers
       (into {}
             (for [ct ["application/edn" "application/json" "text/html"]]

--- a/test/yada/webjar_resource_test.clj
+++ b/test/yada/webjar_resource_test.clj
@@ -1,0 +1,16 @@
+(ns yada.webjar-resource-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [yada.resources.webjar-resource :refer [new-webjar-resource]]
+            [clojure.java.io :as io]
+            [clojure.java.io :as io]
+            [yada.test :as test]))
+
+(deftest bootstrap-test
+  (let [expected (slurp (io/resource "META-INF/resources/webjars/bootstrap/3.3.6/less/close.less"))]
+    (is (= expected
+           (:body (test/response-for ["" (new-webjar-resource "bootstrap"
+                                                              {:index-files ["close.less"]})]
+                                     :get "/less/"))))
+    (is (= expected
+           (:body (test/response-for ["" (new-webjar-resource "bootstrap")]
+                                     :get "/less/close.less"))))))


### PR DESCRIPTION
Webjars have a structure that means when using the normal classpath
resource you have to hardcode the version number of the webjar in the
resource name. This commit adds a webjar resource that eliminates this
problem.

This fixes #99 