### PR TITLE
Allow resources to define :part-consumer for multipart uploads

### DIFF
--- a/src/yada/multipart.clj
+++ b/src/yada/multipart.clj
@@ -590,8 +590,9 @@
         boundary (get-in content-type [:parameters "boundary"])
         request-buffer-size CHUNK-SIZE ; as Aleph default, TODO: derive this
         window-size (* 4 request-buffer-size)
-        ;; TODO: No options now, create alternative way of changing the part consumer
-        part-consumer (get-in ctx [:options :part-consumer] (->DefaultPartConsumer))]
+        part-consumer (get-in ctx
+                              [:resource :methods (:method ctx) :part-consumer]
+                              (->DefaultPartConsumer))]
     (cond
       (not boundary) (throw (ex-info "No boundary parameter in multipart" {:status 400}))
       :otherwise

--- a/src/yada/schema.clj
+++ b/src/yada/schema.clj
@@ -210,8 +210,11 @@ convenience of terse, expressive short-hand descriptions."}
 
 (s/defschema Consumer
   "A consumer is a reducing function that is called with the request's
-  body payload chunks"
-  {(s/optional-key :consumer) (s/=> Context Context s/Any)})
+  body payload chunks. Alternately, a resource can define a multipart consumer
+  implementing `yada.multipart/PartConsumer` which will be used for multipart
+  form-data requests."
+  {(s/optional-key :consumer) (s/=> Context Context s/Any)
+   (s/optional-key :part-consumer) s/Any})
 
 (s/defschema MethodParametersCoercionMatchers
   "A map of coercion matchers as required by `schema.coerce/coercer`."


### PR DESCRIPTION
Following up on #74, there's currently no way to provide custom `PartConsumer` implementations to yada to handle large multipart uploads. This change adds `:part-consumer` as a valid resource definition key, and uses it to look up the implementation to use, falling  back to the default.

A multipart-post resource could look like this now:
```clojure
(yada/resource
  {:methods {:post {:summary "Uploads a file with a multipart POST"
                    :consumes ["multipart/form-data"]
                    :part-consumer (->StreamPartConsumer "/tmp/landing")
                    :response (fn [ctx] ...)}})
```