### PR TITLE
Add support for responses to swagger

### DIFF
--- a/src/yada/schema.clj
+++ b/src/yada/schema.clj
@@ -15,6 +15,7 @@ convenience of terse, expressive short-hand descriptions."}
    [yada.boolean :as b :refer [boolean?]]
    [yada.representation :as rep]
    [yada.media-type :as mt]
+   [yada.util :refer [disjoint*?]]
    [schema.core :as s]
    [schema.coerce :as sc]
    [schema.utils :refer [error?]]
@@ -272,15 +273,6 @@ convenience of terse, expressive short-hand descriptions."}
 
 ;; Responses
 
-(defn disjoint-statii?
-  "Checks that responses keys are disjoint. Meaning a given status matches only one key in the
-  responses map."
-  [responses]
-  (let [direct (set (filter #(not (set? %)) (keys (dissoc responses *))))
-        sets (cons direct (filter set? (keys responses)))]
-    (= (reduce + (map count sets))
-       (count (apply set/union sets)))))
-
 (defn wildcard? "is this the wildcard response" [fn]
   (= fn *))
 
@@ -293,8 +285,8 @@ convenience of terse, expressive short-hand descriptions."}
                {(s/optional-key :description) s/Str}
                Produces
                Response
-               )}
-     disjoint-statii?)})
+               NamespacedEntries)}
+     disjoint*?)})
 
 
 ;; Many HTTP headers are comma separated. We should accept these

--- a/src/yada/schema.clj
+++ b/src/yada/schema.clj
@@ -197,9 +197,15 @@ convenience of terse, expressive short-hand descriptions."}
   {(s/optional-key :description) String
    (s/optional-key :summary) String})
 
+(defn wildcard? "is this the wildcard response" [fn]
+  (= fn *))
+
+(s/defschema Statii (s/conditional integer? s/Int set? #{s/Int} fn? (s/pred wildcard?)))
+
 (s/defschema MethodDocumentation
   (merge CommonDocumentation
-         {(s/optional-key :responses) {s/Int {:description String}}}))
+         {(s/optional-key :responses) {Statii (merge {:description String}
+                                                     NamespacedEntries)}}))
 
 (s/defschema MethodParameters
   (merge-with
@@ -270,13 +276,6 @@ convenience of terse, expressive short-hand descriptions."}
     ContextFunction as-fn}
    RepresentationSeqMappings
    AuthorizationMappings))
-
-;; Responses
-
-(defn wildcard? "is this the wildcard response" [fn]
-  (= fn *))
-
-(s/defschema Statii (s/conditional integer? s/Int set? #{s/Int} fn? (s/pred wildcard?)))
 
 (s/defschema Responses
   {(s/optional-key :responses)

--- a/test/yada/statii_test.clj
+++ b/test/yada/statii_test.clj
@@ -1,7 +1,7 @@
 (ns yada.statii-test
   (:require
    [clojure.test :refer :all]
-   [yada.util :refer [get*]]))
+   [yada.util :refer [get* dissoc* assoc* conj* merge* disjoint*? expand]]))
 
 (deftest get*-test
   (let [m {400 :a
@@ -18,3 +18,97 @@
     (is (nil? (get* {400 :a} 401))))
   (is (= :a (get* {400 :a #{400 401} :b} 400))))
 
+(deftest disjoint*?-test
+  (is (= true (disjoint*? {200 :a * :b})))
+  (is (= true (disjoint*? {200 :a (set (range 201 209)) :b})))
+  (is (= true (disjoint*? {#{200 202} :a #{201 203} :b})))
+  (is (= false (disjoint*? {200 :a #{200 201} :b})))
+  (is (= false (disjoint*? {#{200 201} :a #{201 202} :b}))))
+
+(deftest dissoc*-test
+  (let [m {200            :a
+           #{400 401 403} :b
+           *              :c}]
+    (testing "missing"
+      (is (= (dissoc* m 201) m))
+      (is (= (dissoc* m #{201 203}) m)))
+    (testing "wildcard"
+      (is (= (dissoc* m *)
+             {200 :a #{400 401 403} :b})))
+    (testing "simply key"
+      (is (= (dissoc* m 200)
+             {#{400 401 403} :b * :c}))
+      (is (= (dissoc* m 400)
+             {200 :a #{401 403} :b * :c})))
+    (testing "set key"
+      (is (= (dissoc* m #{200 401})
+             {#{400 403} :b * :c}))
+      (is (= (dissoc* m #{201 401 403})
+             {200 :a 400 :b * :c}))
+      (is (= (dissoc* m #{200 400 401 403})
+             {* :c})))
+    (is (= (dissoc* m 200 #{400 401} 403)
+           {* :c}))))
+
+(deftest assoc*-test
+  (let [m {200            :a
+           #{400 401 403} :b
+           *              :c}]
+    (testing "simple key"
+      (is (= (assoc* m 201 :d)
+             {200 :a 201 :d #{400 401 403} :b * :c})
+          "adds missing simple key")
+      (is (= (assoc* m 200 :d)
+             {200 :d #{400 401 403} :b * :c})
+          "replaces simple key")
+      (is (= (assoc* m 400 :d)
+             {200 :a #{401 403} :b 400 :d * :c})
+          "removes from set key and adds simple key"))
+    (is (= (assoc* m * :d)
+           {200 :a #{400 401 403} :b * :d}))
+    (testing "set key"
+      (is (= (assoc* m #{201 203} :d)
+             {200 :a #{201 203} :d #{400 401 403} :b * :c}))
+      (is (= (assoc* m #{200 401} :d)
+             {#{400 403} :b #{200 401} :d * :c}))
+      (is (= (assoc* m #{201 401 403} :d)
+             {200 :a 400 :b #{201 401 403} :d * :c}))
+      (is (= (assoc* m #{200 400 401 403} :d)
+             {#{200 400 401 403} :d * :c})))
+    (is (= (assoc* m 200 :d #{400 401} :e 403 :f)
+           {200 :d #{400 401} :e 403 :f * :c}))))
+
+(deftest conj*-test
+  (let [m {200            :a
+           #{400 401 403} :b
+           *              :c}
+        d {200 :a
+           201 :d
+           #{400 401 403} :b
+           * :c}]
+    (is (= (conj* m [201 :d]) d))
+    (is (= (conj* m (first {201 :d})) d))
+    (is (= (conj* m (seq {201 :d})) d))
+    (is (= (conj* m {201 :d} {}) d))
+    (is (= (conj* m {200 :q #{400 401} :e} [403 :f] [200 :d])
+           {200 :d #{400 401} :e 403 :f * :c}))))
+
+(deftest merge*-test
+  (is (= (merge* {}
+                 {200 :q 401 :m * :c}
+                 nil
+                 {#{400 401 403} :b 200 :s}
+                 {200 :a})
+         {200            :a
+          #{400 401 403} :b
+          *              :c})))
+
+(deftest expand-test
+  (is (= {100 :a} (expand {100 :a})))
+  (is (= {* :a} (expand {* :a})))
+  (is (= {100 :a * :b 201 :c 204 :c 500 :d 404 :e 300 :e 203 :e}
+         (expand {100            :a
+                  *              :b
+                  #{201 204}     :c
+                  #{500}         :d
+                  #{404 300 203} :e}))))

--- a/test/yada/swagger_test.clj
+++ b/test/yada/swagger_test.clj
@@ -180,6 +180,29 @@
                [["/api/" [long :id]] (resource {:parameters {:path {:name String}}
                                                 :methods    {:get {:parameters {:path {:time String}}
                                                                    :response   (constantly nil)}}})])))))
+  (testing "responses"
+    (is (= {:paths {"/api" {:get {:responses {200      {:description "OK"}
+                                              301      {:description "Redirect"}
+                                              302      {:description "Redirect"}
+                                              :default {:description "default"}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:methods {:get {:responses {200        {:description "OK"}
+                                                            #{301 302} {:description "Redirect"}
+                                                            *          {:description "default"}}
+                                                :response  (fn [_] nil)}}})])))
+    (is (= {:paths {"/api" {:get {:responses {200      {:description "OK"}
+                                              301      {:description "Redirect"}
+                                              302      {:description "Redirect"}
+                                              400      {:description "Bad"}
+                                              :default {:description "default"}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:responses {#{302 400} {:description "Bad"
+                                                        :produces    "text/plain"
+                                                        :response (constantly nil)}}
+                                :methods {:get {:responses {200        {:description "OK"}
+                                                            #{301 302} {:description "Redirect"}
+                                                            *          {:description "default"}}
+                                                :response  (fn [_] nil)}}})]))))
   (testing "swagger namespace keys"
     (is (= {:paths {"/api" {:get {:tags ["test"]}}}}
            (routes->ring-swagger-spec
@@ -194,6 +217,12 @@
              ["/api" (resource {:swagger/tags ["test"]
                                 :methods {:get {:swagger/tags ["get-stuff"]
                                                 :response   (fn [_] nil)}}})])))
+    (is (= {:paths {"/api" {:get {:responses {200 {:description "OK"
+                                                   :schema String}}}}}}
+           (routes->ring-swagger-spec
+             ["/api" (resource {:methods      {:get {:responses {200 {:description "OK"
+                                                                      :swagger/schema String}}
+                                                     :response  (fn [_] nil)}}})])))
     ))
 
 #_(select-keys


### PR DESCRIPTION
This changes the schema for method documentation responses key so that the keys now match what is allowed as keys in the resource responses key (i.e. integers, sets of integers and *) and allows namespaced keys in the methods responses values.

It also adds a merged version of the resource responses and method documentation responses to the swagger spec with * key mapped to the default swagger responses key.
