### PR TITLE
Fixes 500 internal server error for swagger-ui

### DIFF
--- a/src/yada/resources/url_resource.clj
+++ b/src/yada/resources/url_resource.clj
@@ -18,9 +18,10 @@
     (resource
      {:properties
       (fn [ctx]
-        {:last-modified (when-let [f (as-file url)]
-                          (when (.exists f)
-                            (Date. (.lastModified f))))})
+        (merge {}
+               (when-let [f (as-file url)]
+                 (when (.exists f)
+                   {:last-modified (Date. (.lastModified f))}))))
 
       :methods
       {:get


### PR DESCRIPTION
Hello,

For the past day, I've been trying to set up the `edge` example project, but the swagger-ui part appeared to be failing with this error:

![hpuka](https://cloud.githubusercontent.com/assets/119317/16873643/dadd6598-4a94-11e6-9b0f-92c508ab267a.png)

After some debugging, I found out that this was being caused by [this piece of offending code](https://github.com/juxt/yada/blob/master/src/yada/resources/url_resource.clj#L22):

```
     (fn [ctx]
        {:last-modified (when-let [f (as-file url)]
                          (when (.exists f)
                            (Date. (.lastModified f))))})
```

When `(.exists f)` returns false, `last-modified` is set to `nil`, which causes the schema validation error. The easy fix for this is to not add the `last-modified` key when the file does not exist, which is what you'll find in this PR.

In addition to this, I think the root cause is probably in `webjar_resource.clj`, because the file to the swagger-ui jar should of course always resolve. I think this has something to do with my Windows environment, given that the url looks like this:

> C:\\Users\\Leon%20Mergen\\.m2\\repository\\org\\webjars\\swagger-ui\\2.1.4\\swagger-ui-2.1.4.jar

However, I am a bit stuck in finding a solution to this.