### PR TITLE
Adds support for x-forwarded-proto header

### DIFF
--- a/src/yada/interceptors.clj
+++ b/src/yada/interceptors.clj
@@ -82,6 +82,29 @@
     (assoc ctx :cookies cookies)
     ctx))
 
+(defn capture-proxy-headers [ctx]
+
+  (let [req (:request ctx)
+
+        scheme (or
+                ;; As defined in RFC 7239
+                (get-in req [:headers "forwarded-proto"])
+
+                ;; Unofficial, but used by Apache and NGINX
+                (get-in req [:headers "x-forwarded-proto"])
+
+                ;; Microsoft-specific extension
+                (when (= "on" (get-in req [:headers "front-end-https"]))
+                  :https)
+
+                ;; We fallback to the detected scheme, which is pretty much
+                ;; always http
+                (:scheme req))
+
+        req' (assoc req :scheme (keyword scheme))]
+
+    (assoc ctx :request req')))
+
 (defn parse-parameters
   "Parse request and coerce parameters. Capture cookies."
   [ctx]

--- a/src/yada/resource.clj
+++ b/src/yada/resource.clj
@@ -68,6 +68,7 @@
    i/TRACE
    i/method-allowed?
    i/parse-parameters
+   i/capture-proxy-headers
    sec/authenticate
    i/get-properties
    sec/authorize

--- a/src/yada/resources/url_resource.clj
+++ b/src/yada/resources/url_resource.clj
@@ -18,9 +18,10 @@
     (resource
      {:properties
       (fn [ctx]
-        {:last-modified (when-let [f (as-file url)]
-                          (when (.exists f)
-                            (Date. (.lastModified f))))})
+        (merge {}
+               (when-let [f (as-file url)]
+                 (when (.exists f)
+                   {:last-modified (Date. (.lastModified f))}))))
 
       :methods
       {:get

--- a/src/yada/security.clj
+++ b/src/yada/security.clj
@@ -175,15 +175,15 @@
 
 (defn security-headers [ctx]
   (let [scheme (-> ctx :request :scheme)
-        https (or (= scheme :https)
-                  (get-in ctx [:request :headers "x-forwarded-for"]))]
+        https? (= scheme :https)]
+
     (cond-> ctx
-      https (assoc-in [:response :headers "strict-transport-security"]
-                      (format
-                       "max-age=%s; includeSubdomains"
-                       (get-in ctx [:strict-transport-security :max-age] 31536000)))
-      https (assoc-in [:response :headers "content-security-policy"]
-                      (get-in ctx [:content-security-policy] "default-src https: data: 'unsafe-inline' 'unsafe-eval'"))
+      https? (assoc-in [:response :headers "strict-transport-security"]
+                       (format
+                        "max-age=%s; includeSubdomains"
+                        (get-in ctx [:strict-transport-security :max-age] 31536000)))
+      https? (assoc-in [:response :headers "content-security-policy"]
+                       (get-in ctx [:content-security-policy] "default-src https: data: 'unsafe-inline' 'unsafe-eval'"))
       true (assoc-in [:response :headers "x-frame-options"]
                      (get ctx :x-frame-options "SAMEORIGIN"))
       true (assoc-in [:response :headers "x-xss-protection"]

--- a/test/yada/security_test.clj
+++ b/test/yada/security_test.clj
@@ -55,3 +55,49 @@
            :get "/" {})]
       (is (= 401 (:status response)))
       (is (= ["Basic realm=\"default\""] (get-in response [:headers "www-authenticate"]))))))
+
+(deftest response-header-test
+  ;; This test validates that the security module sends the correct headers
+  ;; based on the protocol used (http/https). This implies we properly detect
+  ;; the protocol, which can be a bit tricky when we're behind a proxy.
+
+
+  (def echo-routes {:methods {:get {:produces #{"application/edn;q=0.9"}
+                                    :response #(:request %)}}})
+
+  (testing "scheme defaults to http"
+    (let [response (response-for echo-routes
+                                 :get "/" {})
+          internal-request (-> response :body read-string)]
+
+      (is (= :http (:scheme internal-request)))))
+
+
+  ;; Which headers we expect to be set, based on the protocol used
+  (def headers {:http ["x-frame-options"
+                       "x-xss-protection"
+                       "x-content-type-options"]
+                :https ["strict-transport-security"
+                        "content-security-policy"
+                        "x-frame-options"
+                        "x-xss-protection"
+                        "x-content-type-options"]})
+
+
+  ;; Different combinations of headers that can be set by proxy servers
+  (def header-possibilities [["x-forwarded-proto" "https" :https]
+                             ["x-forwarded-proto" "http" :http]
+                             ["forwarded-proto" "https" :https]
+                             ["forwarded-proto" "http" :http]])
+
+  (testing "scheme is properly detected from valid header combinations"
+    (doseq [[key value expected] header-possibilities]
+      (let [response (response-for echo-routes
+                                   :get "/" {:headers {key value}})
+            internal-request (-> response :body read-string)
+            expected-headers (expected headers)]
+
+        (is (= expected (:scheme internal-request)))
+
+        (doseq [header expected-headers]
+          (is (contains? (:headers response) header)))))))

--- a/test/yada/security_test.clj
+++ b/test/yada/security_test.clj
@@ -88,7 +88,9 @@
   (def header-possibilities [["x-forwarded-proto" "https" :https]
                              ["x-forwarded-proto" "http" :http]
                              ["forwarded-proto" "https" :https]
-                             ["forwarded-proto" "http" :http]])
+                             ["forwarded-proto" "http" :http]
+                             ["front-end-https" "on" :https]
+                             ["front-end-https" "off" :http]])
 
   (testing "scheme is properly detected from valid header combinations"
     (doseq [[key value expected] header-possibilities]


### PR DESCRIPTION
As discussed in #113, this PR adds support for the FORWARED-PROTO http header, along with a bunch of other semi-standard headers. It has been implemented as an interceptor, due to the flexibility that this brings.

Perhaps it's a good idea if we refactor this into a bigger `proxy` interceptor/module, in which we also properly handle `forwarded-by`, `forwarded-for` and `forwarded-host` headers.