### PR TITLE
Use keyword for ns import

### DIFF
--- a/src/yada/resources/sse.clj
+++ b/src/yada/resources/sse.clj
@@ -9,7 +9,7 @@
    clojure.core.async.impl.channels
    clojure.core.async.impl.protocols
    manifold.stream.async)
-  (import [clojure.core.async.impl.protocols ReadPort]))
+  (:import [clojure.core.async.impl.protocols ReadPort]))
 
 (extend-protocol ResourceCoercion
   ReadPort


### PR DESCRIPTION
This change makes yada compile under Clojure 1.9.0-alpha11, in which ns forms are now spec'd