### PR TITLE
Request body coercion

### DIFF
--- a/src/yada/request_body.clj
+++ b/src/yada/request_body.clj
@@ -95,97 +95,110 @@
 ;; Looking for multipart/form-data? Its defmethod can be found in
 ;; yada.multipart.
 
+(defmulti parse-stream (fn [media-type stream] media-type))
+
+(defmulti default-matcher identity)
+
+(defmethod default-matcher :default [_] (constantly nil))
+
+(defn- coerced! [raw-data schema schema->matcher]
+  (let [coercer (sc/coercer schema schema->matcher)
+        result (coercer raw-data)]
+    (when (error? result)
+      (throw (ex-info "Malformed body" {:status 400 :error (error-val result)})))
+    result))
+
+(defn parse-coerce-stream [stream media-type schema matcher]
+  (let [parsed (parse-stream media-type stream)]
+    (cond->
+      {:parsed parsed}
+      schema (assoc :coerced (coerced! parsed schema (or matcher (default-matcher media-type)))))))
+
+(defn- body-schema [ctx]
+  (get-in ctx [:resource :methods (:method ctx) :parameters :body]))
+
+(defn- body-matcher [ctx]
+  (get-in ctx [:resource :methods (:method ctx) :coercion-matchers :body]))
+
+(defn- default-process-request-body
+  [ctx body-stream media-type & _]
+  (let [result (parse-coerce-stream
+                 body-stream
+                 media-type
+                 (body-schema ctx)
+                 (body-matcher ctx))]
+    (cond-> (assoc-in ctx [:body] (:parsed result))
+            (contains? result :coerced) (assoc-in [:parameters :body] (:coerced result)))))
+
 (defmacro with-400-maybe [& body]
   `(try
      ~@body
      (catch Exception e#
        (throw (ex-info "Malformed body" {:status 400} e#)))))
 
-(defn coerced-body [body schema schema->matcher]
-  (let [coercer (sc/coercer schema schema->matcher)
-        result (coercer body)]
-    (when (error? result)
-      (throw (ex-info "Malformed body" {:status 400 :error (error-val result)})))
-    result))
-
-(defmulti parse-stream (fn [media-type stream] media-type))
-
-(defmethod parse-stream :default
-  [_ stream]
-  stream)
+;; text/plain
 
 (defmethod parse-stream "text/plain"
   [_ stream]
-  (with-400-maybe (bs/to-string stream)))
+  (-> (bs/to-string stream)
+      (with-400-maybe)))
 
+(defmethod default-matcher "text/plain" [_]
+  sc/string-coercion-matcher)
 
 (defmethod process-request-body "text/plain"
-  [ctx body-stream media-type & args]
-  (let [body (parse-stream media-type body-stream)
-        schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])
-        matcher (get-in ctx [:resource :methods (:method ctx) :coercion-matchers :body])
-        schema->matcher (or matcher sc/string-coercion-matcher)
-        coerced-body #(coerced-body body schema schema->matcher)]
-    (cond-> ctx
-            true (assoc-in [:body] body)
-            schema (assoc-in [:parameters :body] (coerced-body)))))
+  [& args]
+  (apply default-process-request-body args))
 
-(defmethod parse-stream "application/edn"
-  [_ stream]
-  (with-400-maybe (edn/read-string (bs/to-string stream))))
-
-(defmethod process-request-body "application/edn"
-  [ctx body-stream media-type & args]
-  (let [body (parse-stream media-type body-stream)
-        schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])
-        matcher (get-in ctx [:resource :methods (:method ctx) :coercion-matchers :body])
-        schema->matcher (or matcher (constantly nil))
-        coerced-body #(coerced-body body schema schema->matcher)]
-    (cond-> ctx
-            true (assoc-in [:body] body)
-            schema (assoc-in [:parameters :body] (coerced-body)))))
+;; application/json
 
 (defmethod parse-stream "application/json"
   [_ stream]
-  (with-400-maybe (json/decode (bs/to-string stream) keyword)))
+  (-> (bs/to-string stream)
+      (json/decode keyword)
+      (with-400-maybe)))
+
+(defmethod default-matcher "application/json" [_]
+  sc/json-coercion-matcher)
 
 (defmethod process-request-body "application/json"
-  [ctx body-stream media-type & args]
-  (let [body (parse-stream media-type body-stream)
-        schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])
-        matcher (get-in ctx [:resource :methods (:method ctx) :coercion-matchers :body])
-        schema->matcher (or matcher sc/json-coercion-matcher)
-        coerced-body #(coerced-body body schema schema->matcher)]
-    (cond-> ctx
-            true (assoc-in [:body] body)
-            schema (assoc-in [:parameters :body] (coerced-body)))))
+  [& args]
+  (apply default-process-request-body args))
+
+;; application/edn
+
+(defmethod parse-stream "application/edn"
+  [_ stream]
+  (-> (bs/to-string stream)
+      (edn/read-string)
+      (with-400-maybe)))
+
+(defmethod process-request-body "application/edn"
+  [& args]
+  (apply default-process-request-body args))
+
+;; application/transit+json
 
 (defmethod parse-stream "application/transit+json"
   [_ stream]
-  (with-400-maybe (transit/read (transit/reader (bs/to-input-stream stream) :json))))
+  (-> (bs/to-input-stream stream)
+      (transit/reader :json)
+      (transit/read)
+      (with-400-maybe)))
 
 (defmethod process-request-body "application/transit+json"
-  [ctx body-stream media-type & args]
-  (let [body (parse-stream media-type body-stream)
-        schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])
-        matcher (get-in ctx [:resource :methods (:method ctx) :coercion-matchers :body])
-        schema->matcher (or matcher (constantly nil))
-        coerced-body #(coerced-body body schema schema->matcher)]
-    (cond-> ctx
-            true (assoc-in [:body] body)
-            schema (assoc-in [:parameters :body] (coerced-body)))))
+  [& args]
+  (apply default-process-request-body args))
+
+;; application/transit+msgpack
 
 (defmethod parse-stream "application/transit+msgpack"
   [_ stream]
-  (with-400-maybe (transit/read (transit/reader (bs/to-input-stream stream) :msgpack))))
+  (-> (bs/to-input-stream stream)
+      (transit/reader :msgpack)
+      (transit/read)
+      (with-400-maybe)))
 
 (defmethod process-request-body "application/transit+msgpack"
-  [ctx body-stream media-type & args]
-  (let [body (parse-stream media-type body-stream)
-        schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])
-        matcher (get-in ctx [:resource :methods (:method ctx) :coercion-matchers :body])
-        schema->matcher (or matcher (constantly nil))
-        coerced-body #(coerced-body body schema schema->matcher)]
-    (cond-> ctx
-            true (assoc-in [:body] body)
-            schema (assoc-in [:parameters :body] (coerced-body)))))
+  [& args]
+  (apply default-process-request-body args))

--- a/test/yada/process_request_body_test.clj
+++ b/test/yada/process_request_body_test.clj
@@ -1,14 +1,21 @@
 (ns ^{:author "Imre Koszo"}
-    yada.process-request-body-test
+yada.process-request-body-test
   (:require
-   [clojure.test :refer :all :exclude [deftest]]
-   [cheshire.core :as json]
-   [schema.core :as s]
-   [schema.test :refer [deftest]]
-   [yada.interceptors :as i]
-   [yada.resource :refer [resource]]
-   [yada.request-body :refer [process-request-body]]
-   [yada.test-util :refer [is-coercing-correctly?]]))
+    [clojure.test :refer :all :exclude [deftest]]
+    [cheshire.core :as json]
+    [schema.core :as s]
+    [schema.test :refer [deftest]]
+    [yada.interceptors :as i]
+    [yada.resource :refer [resource]]
+    [yada.request-body :refer [process-request-body]]
+    [yada.test-util :refer [is-coercing-correctly?]]
+    [byte-streams :as bs]
+    [schema.coerce :as sc]
+    [cognitect.transit :as transit])
+  (:import (clojure.lang ExceptionInfo Keyword)
+           (java.io ByteArrayOutputStream)))
+
+(declare thrown?)
 
 (def ^:private test-map {:a "Hello" :b :foo :c [4 5 6]})
 
@@ -25,49 +32,255 @@
     (testing (str "coercing " content-type)
       (is-coercing-correctly? test-map s content-type))))
 
-(defn process [body-schema body]
-  (let [resource (resource
-                  {:methods
-                   {:post
-                    {:consumes "application/json"
-                     :parameters {:body body-schema}
-                     :response ""}}})
-        ctx {:method :post
-             :request {:headers
-                       {"content-length" (str (count body))
-                        "content-type" "application/json"}
-                       :body body}
+(defn post-resource [resource body content-type]
+  (let [ctx {:method   :post
+             :request  {:headers
+                              {"content-length" (str (count (bs/to-byte-array body)))
+                               "content-type"   content-type}
+                        :body (bs/to-input-stream body)}
              :resource resource}]
 
     (i/process-request-body ctx)))
 
+(defn process-body
+  ([content-type body-schema body]
+   (process-body content-type body-schema nil body))
+  ([content-type body-schema body-matcher body]
+   (post-resource
+     (resource
+       {:methods
+        {:post
+         (merge {:consumes   content-type
+                 :parameters {:body body-schema}
+                 :response   ""}
+                (when body-matcher
+                  {:coercion-matchers {:body body-matcher}}))}})
+     body
+     content-type)))
+
+(def process-json-body (partial process-body "application/json"))
+(def process-edn-body (partial process-body "application/edn"))
+(def process-plaintext-body (partial process-body "text/plain"))
+(def process-transit-json-body (partial process-body "application/transit+json"))
+(def process-transit-msgpack-body (partial process-body "application/transit+msgpack"))
+
 ;; TODO: test 400 errors
 ;; TODO: transit
 
-(deftest post-parameter-coercion-test
+(deftest json-test
   (testing "happy path"
     (is (= {:foo "bar"}
-           (get-in (process {:foo s/Str}
-                            (json/encode {:foo "bar"})
-                            ) [:parameters :body])))
+           (get-in (process-json-body {:foo s/Str}
+                                      (json/encode {:foo "bar"}))
+                   [:parameters :body])))
     (is (= {:foo :yoyo}
-           (get-in (process {:foo s/Keyword}
-                            (json/encode {:foo :yoyo})
-                            ) [:parameters :body])))
+           (get-in (process-json-body {:foo s/Keyword}
+                                      (json/encode {:foo :yoyo}))
+                   [:parameters :body])))
     (is (= {:foo :yoyo}
-           (get-in (process {:foo clojure.lang.Keyword}
-                            (json/encode {:foo :yoyo})
-                            ) [:parameters :body])))
+           (get-in (process-json-body {:foo Keyword}
+                                      (json/encode {:foo :yoyo}))
+                   [:parameters :body])))
     (is (= {:foo :yoyo}
-           (get-in (process {:foo (s/eq :yoyo)}
-                            (json/encode {:foo :yoyo})
-                            ) [:parameters :body])))
-    (is (= {:foo :yoyo}
-           (get-in (process {:foo (s/enum :yoyo :bar)}
-                            (json/encode {:foo :yoyo})
-                            ) [:parameters :body]))))
+           (get-in (process-json-body {:foo (s/eq :yoyo)}
+                                      (json/encode {:foo :yoyo}))
+                   [:parameters :body])))
+
+    (let [processed (process-json-body {:foo (s/enum :yoyo :bar)}
+                                       (json/encode {:foo :yoyo}))]
+      (is (= {:foo :yoyo} (get-in processed [:parameters :body])))
+      (is (= {:foo "yoyo"} (get-in processed [:body]))))
+
+    (is (= 5
+           (get-in (process-json-body s/Int
+                                      (json/encode 5))
+                   [:parameters :body])))
+
+    (let [processed (process-json-body {:foo s/Int}
+                                       #(when (= s/Int %) (constantly 1234))
+                                       (json/encode {:foo 9999}))]
+      (is (= {:foo 1234} (get-in processed [:parameters :body])))
+      (is (= {:foo 9999} (get-in processed [:body])))))
+
   (testing "sad path"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (get-in (process {:foo s/Str}
-                                  (json/encode {:foo 123})
-                                  ) [:parameters :body])))))
+    (is (thrown?
+          ExceptionInfo
+          (get-in
+            (process-json-body
+              {:foo s/Str}
+              (json/encode {:foo 123}))
+            [:parameters :body])))))
+
+(deftest edn-test
+  (testing "happy path"
+    (is (= {:foo "bar"}
+           (get-in (process-edn-body {:foo s/Str}
+                                     (pr-str {:foo "bar"}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-edn-body {:foo s/Keyword}
+                                     (pr-str {:foo :yoyo}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-edn-body {:foo Keyword}
+                                     (pr-str {:foo :yoyo}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-edn-body {:foo (s/eq :yoyo)}
+                                     (pr-str {:foo :yoyo}))
+                   [:parameters :body])))
+
+    (let [processed (process-edn-body {:foo (s/enum :yoyo :bar)}
+                                      (pr-str {:foo :yoyo}))]
+      (is (= {:foo :yoyo} (get-in processed [:parameters :body])))
+      (is (= {:foo :yoyo} (get-in processed [:body]))))
+
+    (is (= 5
+           (get-in (process-edn-body s/Int
+                                     (pr-str 5))
+                   [:parameters :body])))
+
+    (let [processed (process-edn-body {:foo s/Int}
+                                      #(when (= s/Int %) (constantly 1234))
+                                      (pr-str {:foo 9999}))]
+      (is (= {:foo 1234} (get-in processed [:parameters :body])))
+      (is (= {:foo 9999} (get-in processed [:body])))))
+
+  (testing "sad path"
+    (is (thrown?
+          ExceptionInfo
+          (get-in
+            (process-edn-body
+              {:foo s/Str}
+              (pr-str {:foo 123}))
+            [:parameters :body])))))
+
+(deftest plaintext-test
+  (testing "happy path"
+    (is (= "foo"
+           (get-in (process-plaintext-body s/Str "foo")
+                   [:parameters :body])))
+    (is (= :foo
+           (get-in (process-plaintext-body s/Keyword "foo")
+                   [:parameters :body])))
+    (is (= :foo
+           (get-in (process-plaintext-body Keyword "foo")
+                   [:parameters :body])))
+    (is (= :yoyo
+           (get-in (process-plaintext-body (s/eq :yoyo) "yoyo")
+                   [:parameters :body])))
+
+    (let [processed (process-plaintext-body s/Int "5")]
+      (is (= 5 (get-in processed [:parameters :body])))
+      (is (= "5" (get-in processed [:body]))))
+
+    (let [processed (process-plaintext-body s/Int
+                                            #(when (= s/Int %) (constantly 1234))
+                                            "9999")]
+      (is (= 1234 (get-in processed [:parameters :body])))
+      (is (= "9999" (get-in processed [:body])))))
+
+  (testing "sad path"
+    (is (thrown?
+          ExceptionInfo
+          (get-in
+            (process-plaintext-body
+              {:foo s/Str}
+              "1234")
+            [:parameters :body])))))
+
+(defn- transit-encode [type v]
+  (let [baos (ByteArrayOutputStream. 100)]
+    (transit/write (transit/writer baos type) v)
+    (.toByteArray baos)))
+
+(def ^:private transit-json (partial transit-encode :json))
+(def ^:private transit-msgpack (partial transit-encode :msgpack))
+
+(deftest transit-json-test
+  (testing "happy path"
+    (is (= {:foo "bar"}
+           (get-in (process-transit-json-body {:foo s/Str}
+                                              (transit-json {:foo "bar"}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-transit-json-body {:foo s/Keyword}
+                                              (transit-json {:foo :yoyo}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-transit-json-body {:foo Keyword}
+                                              (transit-json {:foo :yoyo}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-transit-json-body {:foo (s/eq :yoyo)}
+                                              (transit-json {:foo :yoyo}))
+                   [:parameters :body])))
+
+    (let [processed (process-transit-json-body {:foo (s/enum :yoyo :bar)}
+                                               (transit-json {:foo :yoyo}))]
+      (is (= {:foo :yoyo} (get-in processed [:parameters :body])))
+      (is (= {:foo :yoyo} (get-in processed [:body]))))
+
+    (is (= 5
+           (get-in (process-transit-json-body s/Int
+                                              (transit-json 5))
+                   [:parameters :body])))
+
+    (let [processed (process-transit-json-body {:foo s/Int}
+                                               #(when (= s/Int %) (constantly 1234))
+                                               (transit-json {:foo 9999}))]
+      (is (= {:foo 1234} (get-in processed [:parameters :body])))
+      (is (= {:foo 9999} (get-in processed [:body])))))
+
+  (testing "sad path"
+    (is (thrown?
+          ExceptionInfo
+          (get-in
+            (process-transit-json-body
+              {:foo s/Str}
+              (transit-json {:foo 123}))
+            [:parameters :body])))))
+
+(deftest transit-msgpack-test
+  (testing "happy path"
+    (is (= {:foo "bar"}
+           (get-in (process-transit-msgpack-body {:foo s/Str}
+                                                 (transit-msgpack {:foo "bar"}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-transit-msgpack-body {:foo s/Keyword}
+                                                 (transit-msgpack {:foo :yoyo}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-transit-msgpack-body {:foo Keyword}
+                                                 (transit-msgpack {:foo :yoyo}))
+                   [:parameters :body])))
+    (is (= {:foo :yoyo}
+           (get-in (process-transit-msgpack-body {:foo (s/eq :yoyo)}
+                                                 (transit-msgpack {:foo :yoyo}))
+                   [:parameters :body])))
+
+    (let [processed (process-transit-msgpack-body {:foo (s/enum :yoyo :bar)}
+                                                  (transit-msgpack {:foo :yoyo}))]
+      (is (= {:foo :yoyo} (get-in processed [:parameters :body])))
+      (is (= {:foo :yoyo} (get-in processed [:body]))))
+
+    (is (= 5
+           (get-in (process-transit-msgpack-body s/Int
+                                                 (transit-msgpack 5))
+                   [:parameters :body])))
+
+    (let [processed (process-transit-msgpack-body {:foo s/Int}
+                                                  #(when (= s/Int %) (constantly 1234))
+                                                  (transit-msgpack {:foo 9999}))]
+      (is (= {:foo 1234} (get-in processed [:parameters :body])))
+      (is (= {:foo 9999} (get-in processed [:body])))))
+
+  (testing "sad path"
+    (is (thrown?
+          ExceptionInfo
+          (get-in
+            (process-transit-msgpack-body
+              {:foo s/Str}
+              (transit-msgpack {:foo 123}))
+            [:parameters :body])))))


### PR DESCRIPTION
- added schema coercion support to text/plain
- made text/plain, json, edn and transit+\* handling uniform
  1. read and parse input according to media type
  2. get schema and matcher from context
  3. get default matcher for media type
  4. coerce using above
- refactored for DRY, SRP and readability (hpefully)
