### PR TITLE
Handle media-type without subtype: "*", "*; q=0.6" etc.

### DIFF
--- a/src/yada/media_type.clj
+++ b/src/yada/media_type.clj
@@ -25,11 +25,17 @@
                    "(" http-token ")"
                    "((?:" OWS ";" OWS http-token "=" http-token ")*)")))
 
+(def media-type-pattern-no-subtype
+  (re-pattern (str "(\\*)"
+                   "((?:" OWS ";" OWS http-token "=" http-token ")*)")))
+
 ;; TODO: Replace memoize with cache to avoid memory exhaustion attacks
 (memoize
  (defn string->media-type [s]
    (when s
-     (let [g (rest (re-matches media-type-pattern s))
+     (let [g (rest (or (re-matches media-type-pattern s)
+                       (concat (take 2 (re-matches media-type-pattern-no-subtype s))
+                               ["*" (last (re-matches media-type-pattern-no-subtype s))])))
            params (into {} (map vec (map rest (re-seq (re-pattern (str ";" OWS "(" http-token ")=(" http-token ")"))
                                                       (last g)))))]
        (->MediaTypeMap

--- a/test/yada/media_type_test.clj
+++ b/test/yada/media_type_test.clj
@@ -15,4 +15,7 @@
       "text/html;charset=utf-8;foo=bar" result
       "text/html; charset=utf-8;foo=bar" result
       "text/html; charset=utf-8;   \tfoo=bar" result
-      "image/png;q=0.5" {:name "image/png" :type "image" :subtype "png" :parameters {} :quality 0.5})))
+      "image/png;q=0.5" {:name "image/png" :type "image" :subtype "png" :parameters {} :quality 0.5}
+      "*/*" {:name "*/*" :type "*" :subtype "*" :parameters {} :quality 1.0}
+      "*" {:name "*/*" :type "*" :subtype "*" :parameters {} :quality 1.0}
+      "*; charset=utf-8; q=0.5" {:name "*/*" :type "*" :subtype "*" :parameters {"charset" "utf-8"} :quality 0.5})))


### PR DESCRIPTION
I use Geoserver, which sends an accept header without a subtype, which made Yada crash (see https://github.com/juxt/yada/issues/120).

This patch fixes it, by handling "*" as a specialcase 
I've added a few tests.