### PR TITLE
Fix for issue #110. Generate http 400 if no body and resource defines…

### DIFF
--- a/src/yada/interceptors.clj
+++ b/src/yada/interceptors.clj
@@ -219,7 +219,11 @@
             ctx)))
 
       ;; else
-      ctx)))
+      (if (get-in ctx [:resource :methods (:method ctx) :parameters :body])
+        (d/error-deferred
+           (ex-info "No body present but body is expected for request."
+                    {:status 400}))
+        ctx))))
 
 (defn select-representation
   "Proactively negotatiate the best representation for the payload

--- a/test/yada/empty_body_test.clj
+++ b/test/yada/empty_body_test.clj
@@ -1,0 +1,42 @@
+(ns yada.empty-body-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [yada.resource :refer [resource]]
+            [yada.handler :refer [handler]]
+            [schema.core :as sc]
+            [ring.mock.request :as mock]))
+
+(deftest no-form-body
+  (let [resource
+        (resource {:consumes [{:media-type #{"application/x-www-form-urlencoded"}}]
+                   :methods {:post {:parameters {:body {:foo sc/Int}}
+                                    :response (fn [ctx] "OK")}}})
+        handler (handler resource)]
+
+    (testing "no form body gives 400 issue #110"
+      (let [req (-> (mock/request :post "/" "")
+                    (mock/content-type "application/x-www-form-urlencoded"))]
+        (is (= (:status @(handler req)) 400))))))
+
+(deftest no-edn-body
+  (let [resource
+        (resource {:consumes [{:media-type #{"application/edn"}}]
+                   :methods {:post {:parameters {:body {:foo sc/Int}}
+                                    :response (fn [ctx] "OK")}}})
+        handler (handler resource)]
+
+    (testing "no edn body gives 400 issue #110"
+      (let [req (-> (mock/request :post "/" "")
+                    (mock/content-type "application/edn"))]
+        (is (= (:status @(handler req)) 400))))))
+
+(deftest no-json-body
+  (let [resource
+        (resource {:consumes [{:media-type #{"application/json"}}]
+                   :methods {:post {:parameters {:body {:foo sc/Int}}
+                                    :response (fn [ctx] "OK")}}})
+        handler (handler resource)]
+
+    (testing "no json body gives 400 issue #110"
+      (let [req (-> (mock/request :post "/" "")
+                    (mock/content-type "application/json"))]
+        (is (= (:status @(handler req)) 400))))))


### PR DESCRIPTION
This is a fix for #110. A relatively simple change to result in a http 400 when no body is present and a `:body` parameter has been defined for the resource.

If this isn't suitable or there is a better way of doing it, let me know!  