### PR TITLE
extend coercion capabilities of json bodies

### DIFF
--- a/src/yada/request_body.clj
+++ b/src/yada/request_body.clj
@@ -159,7 +159,7 @@
       (with-400-maybe)))
 
 (defmethod default-matcher "application/json" [_]
-  sc/json-coercion-matcher)
+  (rsc/coercer :json))
 
 (defmethod process-request-body "application/json"
   [& args]


### PR DESCRIPTION
This is a fix for #128 

It uses the json coercer from ring-swagger instead.
