### PR TITLE
Doc: Correct link to Bidi Readme

### DIFF
--- a/doc/routing.adoc
+++ b/doc/routing.adoc
@@ -72,7 +72,7 @@ A yada handler (created by yada's `yada` function) and a yada resource
 of an incoming request's URI.
 
 For a more thorough introduction to bidi, see
-https://github.com/juxt/bidi/README.md.
+https://github.com/juxt/bidi#bidi.
 
 === Declaring policies across multiple resources
 


### PR DESCRIPTION
Could also be https://github.com/juxt/bidi/blob/master/README.md but that depends on the file format, the chosen link always goes to what Github thinks is the Readme
