### PR TITLE
Assoc top level request headers into parts

### DIFF
--- a/src/yada/multipart.clj
+++ b/src/yada/multipart.clj
@@ -607,6 +607,7 @@
 (defmethod process-request-body "multipart/form-data"
   [ctx body-stream media-type & args]
   (let [content-type (mt/string->media-type (get-in ctx [:request :headers "content-type"]))
+        request-headers (get-in ctx [:request :headers])
         boundary (get-in content-type [:parameters "boundary"])
         request-buffer-size CHUNK-SIZE ; as Aleph default, TODO: derive this
         window-size (* 4 request-buffer-size)
@@ -622,7 +623,8 @@
             ;; (or part beginning) to have a content-disposition header,
             ;; let's use a transducer to add that info into the part,
             ;; before we hand the part off to the PartConsumer.
-            (s/transform (comp (xf-add-header-info)
+            (s/transform (comp (map #(assoc % :request-headers request-headers))
+                               (xf-add-header-info)
                                (xf-parse-content-disposition)))
             ;; Now we assemble (via reduction) the parts. We pass each
             ;; part (or partial part) to a consumer that assembles and

--- a/src/yada/util.clj
+++ b/src/yada/util.clj
@@ -62,7 +62,7 @@
 
 ;; ETags
 
-(defn md5-hash [s]
+(defn md5-hash [^String s]
   (let [digest
         (doto
             (java.security.MessageDigest/getInstance "MD5")
@@ -118,7 +118,7 @@
 
 ;; URLs
 
-(defn as-file [resource]
+(defn as-file [^java.net.URL resource]
   (when resource
     (case (.getProtocol resource)
       "file" (io/file (.getFile resource))
@@ -263,7 +263,7 @@
 ;; Arity
 
 (defn arity [f]
-  (let [m (first (.getDeclaredMethods (class f)))
+  (let [^java.lang.reflect.Method m (first (.getDeclaredMethods (class f)))
         p (.getParameterTypes m)]
     (alength p)))
 


### PR DESCRIPTION
This change allows parts of multipart requests to access the headers for the surrounding request. This can be very useful for access user access tokens present in the request headers or any other contextual information pertaining to the request as a whole that could influence the process of a part.
