### PR TITLE
Handle Content-Encoding header

### DIFF
--- a/src/yada/resource.clj
+++ b/src/yada/resource.clj
@@ -72,6 +72,7 @@
    sec/authenticate
    i/get-properties
    sec/authorize
+   i/process-content-encoding
    i/process-request-body
    i/check-modification-time
    i/select-representation

--- a/test/yada/content_encoding_test.clj
+++ b/test/yada/content_encoding_test.clj
@@ -1,0 +1,59 @@
+(ns ^{:author "Johannes Staffans"}
+ yada.content-encoding-test
+  (:require [byte-streams :as bs]
+            [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [manifold.deferred :as d]
+            [ring.mock.request :refer [header request]]
+            [cheshire.core :as json]
+            [yada
+             [interceptors :as i]
+             [yada :refer [resource yada]]])
+  (:import java.io.ByteArrayOutputStream
+           [java.util.zip GZIPInputStream GZIPOutputStream]))
+
+(defn gzip
+  [in out]
+  (with-open [gzipped-out (-> out GZIPOutputStream.)]
+    (io/copy in gzipped-out)))
+
+(defn to-gzipped-byte-array
+  [content]
+  (let [baos    (ByteArrayOutputStream.)
+        _       (gzip content baos)]
+    (.toByteArray baos)))
+
+(defn post-text-plain-resource
+  []
+  (resource
+   {:methods
+    {:post
+     {:produces "text/plain"
+      :consumes "text/plain"
+      :response (fn [ctx] (:body ctx))}}}))
+
+(deftest content-encoding-test
+  (testing "Non-gzipped body"
+    (let [handler  (yada (post-text-plain-resource))
+          content  "test body"
+          response @(handler (-> (request :post "/" content)
+                                 (header "Content-type" "text/plain")))]
+      (is (= 200 (-> response :status)))
+      (is (= "test body" (-> response :body bs/to-string)))))
+
+  (testing "Gzipped body"
+    (let [handler  (yada (post-text-plain-resource))
+          content  (to-gzipped-byte-array "test body")
+          response @(handler (-> (request :post "/" content)
+                                 (header "Content-type" "text/plain")
+                                 (header "Content-encoding" "gzip")))]
+      (is (= 200 (-> response :status)))
+      (is (= "test body" (-> response :body bs/to-string)))))
+
+  (testing "Unsupported Content-encoding"
+    (let [handler  (yada (post-text-plain-resource))
+          content  (to-gzipped-byte-array "test body")
+          response @(handler (-> (request :post "/" content)
+                                 (header "Content-type" "text/plain")
+                                 (header "Content-encoding" "deflate")))]
+      (is (= 415 (-> response :status))))))


### PR DESCRIPTION
This is an attempt to fix #95 (`Content-Encoding: gzip` request header). Only gzip compression is handled at the moment. Decompression is done using a manifold future.

Resources:

* [RFC 2616 Section 14.11: Content-Encoding](https://tools.ietf.org/html/rfc2616#page-118)
* [Content-Encoding on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) 