### PR TITLE
custom error with :body

### DIFF
--- a/src/yada/body.clj
+++ b/src/yada/body.clj
@@ -57,6 +57,7 @@
   ;; A String is already its own representation, all we must do now is encode it to a char buffer
   (to-body [s representation]
     (encode-message s representation))
+  (content-length [_] nil)
 
   Long
   (to-body [l representation]
@@ -71,27 +72,33 @@
   MapBody
   (to-body [mb representation]
     (to-body (:map mb) representation))
+  (content-length [_] nil)
 
   clojure.lang.APersistentMap
   (to-body [m representation]
     ;; We always try to arrive at a string which is then converted
     (encode-message (render-map m representation) representation))
+  (content-length [_] nil)
 
   clojure.lang.APersistentVector
   (to-body [v representation]
     (encode-message (render-seq v representation) representation))
+  (content-length [_] nil)
 
   clojure.lang.ASeq
   (to-body [v representation]
     (encode-message (render-seq v representation) representation))
+  (content-length [_] nil)
 
   clojure.lang.LazySeq
   (to-body [v representation]
     (encode-message (render-seq v representation) representation))
+  (content-length [_] nil)
 
   java.util.HashSet
   (to-body [v representation]
     (encode-message (render-seq v representation) representation))
+  (content-length [_] nil)
 
   File
   (to-body [f _]

--- a/src/yada/handler.clj
+++ b/src/yada/handler.clj
@@ -145,7 +145,7 @@
                               rep (assoc-in [:response :produces] rep)
 
                               (contains? data :body)
-                              (assoc [:response :body] (:body data))
+                              (assoc-in [:response :body] (:body data))
 
                               (and (not (contains? data :body)) (not (:response custom-response)))
                               (standard-error status e rep)

--- a/test/yada/custom_error_response_test.clj
+++ b/test/yada/custom_error_response_test.clj
@@ -56,3 +56,54 @@
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler"))))))
+
+(deftest custom-error-with-body
+  (testing "GET custom error with response body [text/plain]"
+    (try
+      (let [handler (yada (error-resource :get (ex-info "Oh!" {:status 400
+                                                               :body "error response body"})))
+            response @(handler (request :get "/"))]
+        (is (= 400 (:status response)))
+        (is (= "error response body" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
+
+  (testing "POST custom error with response body [text/plain]"
+    (try
+      (let [handler (yada (error-resource :post (ex-info "Oh!" {:status 400
+                                                                :body "error response body"})))
+            response @(handler (request :post "/"))]
+        (is (= 400 (:status response)))
+        (is (= "error response body" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
+
+  (testing "GET custom error with response body [application/json]"
+    (try
+      (let [resource (error-resource :get (ex-info "Oh!" {:status 400
+                                                          :body {:message "custom error message"}}))
+            resource' (assoc-in resource [:methods :get :produces] "application/json")
+            handler (yada resource')
+            response @(handler (request :get "/"))]
+        (is (= 400 (:status response)))
+        (is (= "application/json" (get-in response [:headers "content-type"])))
+        (is (= "{\"message\":\"custom error message\"}\n" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
+
+  (testing "POST custom error with response body [application/json]"
+    (try
+      (let [resource (error-resource :post (ex-info "Oh!" {:status 400
+                                                          :body {:message "custom error message"}}))
+            resource' (assoc-in resource [:methods :post :produces] "application/json")
+            handler (yada resource')
+            response @(handler (request :post "/"))]
+        (is (= 400 (:status response)))
+        (is (= "application/json" (get-in response [:headers "content-type"])))
+        (is (= "{\"message\":\"custom error message\"}\n" (b/to-string (:body response)))))
+      (catch Exception e
+        (let [error-handled? (nil? e)]
+          (is error-handled? "clojure.lang.ExceptionInfo not caught by handler"))))))


### PR DESCRIPTION
Hi, this is a fix for #140, where throwing `(ex-info "..." {:status X :body Y})` in the handler fn was respecting the `:status` but `:body` was being lost.

It looks like `assoc` was the problem [on this line](https://github.com/juxt/yada/blob/e17c218f24b2ec5fd4e6dcc99e4b069046680e91/src/yada/handler.clj#L148) so I changed it to `assoc-in`, but then it was complaining about `content-length` fn not being there, so I added a bunch of `(content-length [_] nil)` which feels hacky, but works.

I added some basic tests for this too.