### PR TITLE
Fix links in documentation

### DIFF
--- a/doc/hello.adoc
+++ b/doc/hello.adoc
@@ -451,7 +451,7 @@ Hello Ken!
 
 Great!
 
-As well as query parameters, yada supports path parameters, request headers, form data, cookies and request bodies. You can have optional parameters, in fact, anything that can be expressed in Plumatic Schema, and [yada]#yada# will even coerce parameters to a range of types. For more details, see the link:parameters.html[Parameters] chapter.
+As well as query parameters, yada supports path parameters, request headers, form data, cookies and request bodies. You can have optional parameters, in fact, anything that can be expressed in Plumatic Schema, and [yada]#yada# will even coerce parameters to a range of types. For more details, see the <<parameters,parameters chapter>>.
 
 [[hello-swagger]]
 === Hello Swagger!

--- a/doc/hello.adoc
+++ b/doc/hello.adoc
@@ -451,7 +451,7 @@ Hello Ken!
 
 Great!
 
-As well as query parameters, yada supports path parameters, request headers, form data, cookies and request bodies. You can have optional parameters, in fact, anything that can be expressed in Plumatic Schema, and [yada]#yada# will even coerce parameters to a range of types. For more details, see the <<parameters,parameters chapter>>.
+As well as query parameters, yada supports path parameters, request headers, form data, cookies and request bodies. You can have optional parameters, in fact, anything that can be expressed in Plumatic Schema, and [yada]#yada# will even coerce parameters to a range of types. For more details, see the <<parameters-chapter,parameters chapter>>.
 
 [[hello-swagger]]
 === Hello Swagger!

--- a/doc/parameters.adoc
+++ b/doc/parameters.adoc
@@ -32,8 +32,8 @@ to define this parameter at the __method-level__, and it's only visible
 if the method we declare it with matches the request method.
 
 We declare parameter values using the syntax of
-https://prismatic.com[Prismatic]'s
-https://github.com/prismatic/schema[schema] library. This allows us to
+https://github.com/plumatic[Plumatic]'s
+https://github.com/plumatic/schema[schema] library. This allows us to
 get quite sophisticated in how we define parameters.
 
 [source,clojure]

--- a/doc/parameters.adoc
+++ b/doc/parameters.adoc
@@ -1,4 +1,4 @@
-[[parameters]]
+[[parameters-chapter]]
 == Parameters
 
 As we learned in <<parameters-intro>>, ((parameters)) declarations are useful to validate and coerce request parameters, produce 400 status responses on bad requests thereby providing some protection against bad input data.

--- a/doc/resources.adoc
+++ b/doc/resources.adoc
@@ -125,7 +125,7 @@ There are benefits to declaring these parameters explicitly:
 * [yada]#yada# will coerce them to the types you want, so you can avoid writing loads of type-conversion logic in your code
 * [yada]#yada# and other tools can process your declarations independently of your request-processing code, e.g. to generate API documentation
 
-Parameter declaration, validation and coercion is a big topic and fully covered in the <<parameters,parameters chapter>>.
+Parameter declaration, validation and coercion is a big topic and fully covered in the <<parameters-chapter,parameters chapter>>.
 
 ==== Representations
 

--- a/doc/routing.adoc
+++ b/doc/routing.adoc
@@ -72,7 +72,7 @@ function) that extends bidi's `Matched` protocol are both able to
 participate in the pattern matching of an incoming request's URI.
 
 For a more thorough introduction to bidi, see
-https://github.com/juxt/bidi/README.md.
+https://github.com/juxt/bidi/blob/master/README.md.
 
 === Declaring policies across multiple resources
 


### PR DESCRIPTION
This should fix #130 - asciidoctor didn't seem to like multiple sections with similar titles or headings.