### PR TITLE
Allow optional body

### DIFF
--- a/src/yada/interceptors.clj
+++ b/src/yada/interceptors.clj
@@ -11,6 +11,7 @@
    [manifold.stream :as stream]
    ring.util.time
    [schema.utils :refer [error?]]
+   [schema.core :as s]
    [yada.body :as body]
    [yada.charset :as charset]
    [yada.cookies :as cookies]
@@ -182,7 +183,13 @@
             ctx)))
 
       ;; else
-      ctx)))
+      (if-let [body-schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])]
+        (if (s/check body-schema nil)
+          (d/error-deferred
+             (ex-info "No body present but body is expected for request."
+                      {:status 400}))
+          ctx)
+        ctx))))
 
 (defn select-representation
   "Proactively negotatiate the best representation for the payload

--- a/src/yada/interceptors.clj
+++ b/src/yada/interceptors.clj
@@ -182,11 +182,7 @@
             ctx)))
 
       ;; else
-      (if (get-in ctx [:resource :methods (:method ctx) :parameters :body])
-        (d/error-deferred
-           (ex-info "No body present but body is expected for request."
-                    {:status 400}))
-        ctx))))
+      ctx)))
 
 (defn select-representation
   "Proactively negotatiate the best representation for the payload


### PR DESCRIPTION
There doesn't seem to be a way to allow an optional body, i.e. allow a body with a schema, or no body at all. Declaring something like this on a method:

`{:parameters {:body (s/maybe {:foo s/Str})}}`

doesn't work, because the presence of any schema, throws a 400 [at this line](https://github.com/juxt/yada/blob/d591f9fc0b470acfa2a52cbff5d0d3b21f497e36/src/yada/interceptors.clj#L187).

@malcolmsparks we discussed this briefly on slack, and you suggested [a slightly different approach](https://clojurians-log.clojureverse.org/yada/2017-01-16.html#inst-2017-01-16T13:52:23.000710Z), the approach taken here is to just remove the check in the else clause, because schema validation further down the interceptor chain takes care of this case, and at first glance it appears we don't need to be so strict here, and can allow a nil body to go through in this place? Do you agree with the approach taken here, or would you rather solve this in another way? If you're cool with this, then I'll fix the failing tests, just wanted to check first.

Thanks!