### PR TITLE
Fix transducer ordering in new-webjar-resource

### DIFF
--- a/bundles/default/test/yada/webjar_resource_test.clj
+++ b/bundles/default/test/yada/webjar_resource_test.clj
@@ -4,7 +4,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is]]
-   [yada.resources.webjar-resource :refer [new-webjar-resource]]
+   [yada.resources.webjar-resource :refer [new-webjar-resource webjars-route-pair]]
    [yada.test :as test]))
 
 (deftest bootstrap-test
@@ -15,4 +15,13 @@
                                      :get "/less/"))))
     (is (= expected
            (:body (test/response-for ["" (new-webjar-resource "bootstrap")]
-                                     :get "/less/close.less"))))))
+                                     :get "/less/close.less"))))
+    (is (= 404
+           (:status (test/response-for ["" (new-webjar-resource "bootstrap")]
+                                       :get "/non/existant/path"))))
+    (is (= expected
+           (:body (test/response-for (webjars-route-pair)
+                                     :get "/bootstrap/less/close.less"))))
+    (is (= 404
+           (:status (test/response-for (webjars-route-pair)
+                                       :get "/bootstrap/non/existant/path"))))))

--- a/ext/webjars/src/yada/resources/webjar_resource.clj
+++ b/ext/webjars/src/yada/resources/webjar_resource.clj
@@ -74,5 +74,7 @@
    (let [webjars (->> (WebJarAssetLocator.)
                       .getWebJars
                       keys
-                      (map (juxt identity #(new-webjar-resource % options))))]
+                      (map (juxt (fn [identifier]
+                                   (str "/" identifier "/"))
+                                 #(new-webjar-resource % options))))]
      ["" webjars])))

--- a/ext/webjars/src/yada/resources/webjar_resource.clj
+++ b/ext/webjars/src/yada/resources/webjar_resource.clj
@@ -61,7 +61,14 @@
                           (as-resource res))))})))
 
 (defn webjars-route-pair
-  ""
+  "Creates webjar resources for all webjars on the active classpath.
+
+  An options map can be provided and will be passed on to the
+  new-webjar-resource call for every webjar.
+
+  Each webjar will be put on a path corresponding to its name. For
+  example, a webjar called \"bootstrap\" will be accessible from the
+  \"/bootstrap/\" path."
   ([] (webjars-route-pair nil))
   ([options]
    (let [webjars (->> (WebJarAssetLocator.)

--- a/ext/webjars/src/yada/resources/webjar_resource.clj
+++ b/ext/webjars/src/yada/resources/webjar_resource.clj
@@ -55,8 +55,8 @@
                               files (if (= (last path-info) \/)
                                       (map #(get assets (str path %)) index-files)
                                       (list (get assets path)))
-                              res (first (sequence (comp (map io/resource)
-                                                         (drop-while nil?))
+                              res (first (sequence (comp (drop-while nil?)
+                                                         (map io/resource))
                                                    files))]
                           (as-resource res))))})))
 


### PR DESCRIPTION
Accessing nonexisting path in webjar resource will result in a NullPointerException because the drop-while function within the transducer `(comp (map io/resource) (drop-while nil?))` is getting called after the io/resource call.