### PR TITLE
Extend HandlerCoercion protocol to handle functions

### DIFF
--- a/src/yada/handler.clj
+++ b/src/yada/handler.clj
@@ -264,6 +264,8 @@
   (as-handler [this] (handler this))
   APersistentMap
   (as-handler [route] (as-handler (resource route)))
+  clojure.lang.Fn
+  (as-handler [this] this)
   Object
   (as-handler [this] (handler this)))
 


### PR DESCRIPTION
Rationale: you may already have fn (for ex. result of `(yada.handler/as-handler bidi-tree)`) which you want to pass to `aleph/listener`.