### PR TITLE
correctly decode query params with request-for

### DIFF
--- a/src/yada/test.clj
+++ b/src/yada/test.clj
@@ -12,7 +12,7 @@
       :server-name "localhost"
       :remote-addr "localhost"
       :uri (.getPath uri)
-      :query-string (.getQuery uri)
+      :query-string (.getRawQuery uri)
       :scheme :http
       :request-method method}
      (cond-> options

--- a/test/yada/parameters_2_test.clj
+++ b/test/yada/parameters_2_test.clj
@@ -69,6 +69,12 @@
                             (s/optional-key "test") Long}}
                    :methods {}}
                   {:query-string "filter=12&test=15"}))))
+
+  (testing "%25 is special since it decodes to %"
+    (is (= {:query {"foo" "bar%"}}
+           (parse {}
+                  {:query-string "foo=bar%25"}))))
+
   (is (thrown? ExceptionInfo
                (parse {:parameters {:query {:filter Long}}
                        :methods {}}

--- a/test/yada/request_for_test.clj
+++ b/test/yada/request_for_test.clj
@@ -1,0 +1,19 @@
+(ns yada.request-for-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [yada.test]))
+
+(deftest request-for-query-params
+  (testing "make sure we're not double-decoding"
+    (is (= (-> {:request (yada.test/request-for :get "/?foo=bar%20" nil)}
+               (yada.parameters/query-parameters))
+           {"foo" "bar "}))
+    (is (= (-> {:request (yada.test/request-for :get "/?foo=bar%25" nil)}
+               (yada.parameters/query-parameters))
+           {"foo" "bar%"})))
+
+  (testing "no decoding should be done in request-for"
+    (is (= (:query-string (yada.test/request-for :get "/?foo=bar%20" nil))
+           "foo=bar%20"))
+    (is (= (:query-string (yada.test/request-for :get "/?foo=bar%25" nil))
+           "foo=bar%25"))))
+


### PR DESCRIPTION
This handles issue #154 

~~The implementation is crude, since it uses regular expressions to get the query-string part of the uri.~~

Updated: There is actually a [`.getRawQuery`](https://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getRawQuery()) on `java.net.URI` instances, so the fix is to just use that instead.
