### PR TITLE
Add with-level macro to silence logging for expected errors

### DIFF
--- a/test/yada/custom_error_response_test.clj
+++ b/test/yada/custom_error_response_test.clj
@@ -6,7 +6,9 @@
    [clojure.test :refer :all]
    [ring.mock.request :refer [request]]
    [yada.handler :refer [handler]]
-   [yada.resource :refer [resource]]))
+   [yada.resource :refer [resource]]
+   [yada.test-util :refer [with-level]])
+  (:import (ch.qos.logback.classic Level)))
 
 (defn- error-resource
   [method exception]
@@ -22,10 +24,11 @@
 (deftest custom-error-response-test []
   (testing "GET custom error for java.lang.Exception"
     (try
-      (let [h (handler (error-resource :get (Exception. "Oh!")))
-            response @(h (request :get "/"))]
-        (is (= 500 (:status response)))
-        (is (= "Error" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [h (handler (error-resource :get (Exception. "Oh!")))
+              response (deref (h (request :get "/")))]
+          (is (= 500 (:status response)))
+          (is (= "Error" (b/to-string (:body response))))))
       (catch Exception e
         ;; prevent stack trace in error report - just show an actionable message
         (let [error-handled? (nil? e)]
@@ -33,30 +36,33 @@
 
   (testing "GET custom error for clojure.lang.ExceptionInfo"
     (try
-      (let [h (handler (error-resource :get (ex-info "Oh!" {})))
-            response @(h (request :get "/"))]
-        (is (= 500 (:status response)))
-        (is (= "Error" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [h (handler (error-resource :get (ex-info "Oh!" {})))
+              response @(h (request :get "/"))]
+          (is (= 500 (:status response)))
+          (is (= "Error" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
 
   (testing "POST custom error for java.lang.Exception"
     (try
-      (let [h (handler (error-resource :post (Exception. "Oh!")))
-            response @(h (request :post "/"))]
-        (is (= 500 (:status response)))
-        (is (= "Error" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [h (handler (error-resource :post (Exception. "Oh!")))
+              response @(h (request :post "/"))]
+          (is (= 500 (:status response)))
+          (is (= "Error" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "java.lang.Exception not caught by handler")))))
 
   (testing "POST custom error for clojure.lang.ExceptionInfo"
     (try
-      (let [h (handler (error-resource :post (ex-info "Oh!" {})))
-            response @(h (request :post "/"))]
-        (is (= 500 (:status response)))
-        (is (= "Error" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [h (handler (error-resource :post (ex-info "Oh!" {})))
+              response @(h (request :post "/"))]
+          (is (= 500 (:status response)))
+          (is (= "Error" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler"))))))
@@ -64,52 +70,56 @@
 (deftest custom-error-with-body
   (testing "GET custom error with response body [text/plain]"
     (try
-      (let [h (handler (error-resource :get (ex-info "Oh!" {:status 400
-                                                            :body "error response body"})))
-            response @(h (request :get "/"))]
-        (is (= 400 (:status response)))
-        (is (= "error response body" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [h (handler (error-resource :get (ex-info "Oh!" {:status 400
+                                                              :body   "error response body"})))
+              response @(h (request :get "/"))]
+          (is (= 400 (:status response)))
+          (is (= "error response body" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
 
   (testing "POST custom error with response body [text/plain]"
     (try
-      (let [h (handler (error-resource :post (ex-info "Oh!" {:status 400
-                                                             :body "error response body"})))
-            response @(h (request :post "/"))]
-        (is (= 400 (:status response)))
-        (is (= "error response body" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [h (handler (error-resource :post (ex-info "Oh!" {:status 400
+                                                               :body   "error response body"})))
+              response @(h (request :post "/"))]
+          (is (= 400 (:status response)))
+          (is (= "error response body" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
 
   (testing "GET custom error with response body [application/edn]"
     (try
-      (let [resource (error-resource :get (ex-info "Oh!" {:status 400
-                                                          :body {:message "custom error message"}}))
-            resource' (assoc-in resource [:methods :get :produces] "application/edn")
-            h (handler resource')
-            response @(h (-> (request :get "/")
-                             (assoc-in [:headers "accept"] "application/edn")))]
-        (is (= 400 (:status response)))
-        (is (= "application/edn" (get-in response [:headers "content-type"])))
-        (is (= "{:message \"custom error message\"}\n" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [resource (error-resource :get (ex-info "Oh!" {:status 400
+                                                           :body   {:message "custom error message"}}))
+             resource' (assoc-in resource [:methods :get :produces] "application/edn")
+             h (handler resource')
+             response @(h (-> (request :get "/")
+                              (assoc-in [:headers "accept"] "application/edn")))]
+         (is (= 400 (:status response)))
+         (is (= "application/edn" (get-in response [:headers "content-type"])))
+         (is (= "{:message \"custom error message\"}\n" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler")))))
 
   (testing "POST custom error with response body [application/json]"
     (try
-      (let [resource (error-resource :post (ex-info "Oh!" {:status 400
-                                                           :body {:message "custom error message"}}))
-            resource' (assoc-in resource [:methods :post :produces] "application/edn")
-            h (handler resource')
-            response @(h (-> (request :post "/")
-                             (assoc-in [:headers "accept"] "application/edn")))]
-        (is (= 400 (:status response)))
-        (is (= "application/edn" (get-in response [:headers "content-type"])))
-        (is (= "{:message \"custom error message\"}\n" (b/to-string (:body response)))))
+      (with-level Level/OFF "yada.handler"
+        (let [resource (error-resource :post (ex-info "Oh!" {:status 400
+                                                             :body   {:message "custom error message"}}))
+              resource' (assoc-in resource [:methods :post :produces] "application/edn")
+              h (handler resource')
+              response @(h (-> (request :post "/")
+                               (assoc-in [:headers "accept"] "application/edn")))]
+          (is (= 400 (:status response)))
+          (is (= "application/edn" (get-in response [:headers "content-type"])))
+          (is (= "{:message \"custom error message\"}\n" (b/to-string (:body response))))))
       (catch Exception e
         (let [error-handled? (nil? e)]
           (is error-handled? "clojure.lang.ExceptionInfo not caught by handler"))))))

--- a/test/yada/logging_test.clj
+++ b/test/yada/logging_test.clj
@@ -4,7 +4,9 @@
   (:require
    [clojure.test :refer :all :exclude [deftest]]
    [schema.test :refer [deftest]]
-   [yada.test :refer [response-for]]))
+   [yada.test :refer [response-for]]
+   [yada.test-util :refer [with-level]])
+  (:import (ch.qos.logback.classic Level)))
 
 ;; Happy path
 (deftest logging-test
@@ -18,10 +20,11 @@
       (is (= :logged! @a))))
 
   (testing "sad path"
-    (let [a (atom nil)
-          res (response-for {:produces "text/plain"
-                             :response (fn [_] (throw (new Exception "Whoops!")))
-                             :logger (fn [ctx] (reset! a :error) nil)})]
+    (with-level Level/OFF "yada.handler"
+      (let [a (atom nil)
+            res (response-for {:produces "text/plain"
+                               :response (fn [_] (throw (new Exception "Whoops!")))
+                               :logger (fn [ctx] (reset! a :error) nil)})]
 
-      (is (= 500 (:status res)))
-      (is (= :error @a)))))
+        (is (= 500 (:status res)))
+        (is (= :error @a))))))

--- a/test/yada/test_util.clj
+++ b/test/yada/test_util.clj
@@ -3,7 +3,9 @@
 (ns ^{:doc "Test utilities"}
  yada.test-util
   (:require
-   [byte-streams :as bs]))
+   [byte-streams :as bs])
+  (:import [ch.qos.logback.classic Logger Level]
+           [org.slf4j LoggerFactory]))
 
 (defn etag? [etag]
   (and (string? etag)
@@ -11,3 +13,14 @@
 
 (defn to-string [s]
   (bs/convert s String))
+
+(defmacro with-level
+  "Sets the logging level for ns to level, while executing body."
+  ;; See http://stackoverflow.com/questions/3837801/how-to-change-root-logging-level-programmatically
+  [level ns & body]
+  `(let [root-logger# ^Logger (LoggerFactory/getLogger ~ns)
+         old-level# (.getLevel root-logger#)]
+     (try
+       (.setLevel root-logger# ~level)
+       ~@body
+       (finally (.setLevel root-logger# old-level#)))))


### PR DESCRIPTION
This patch turns off logging for a namespace when running tests that are expected to log errors.

The with-level macro grabs the logger for the specified namespace, sets it to the required level, executes the body, then sets it back. It's pretty gross to reach into the logging implementation to do this, but as far as I can tell, this is the best option.

This could be made a little more targeted to just a single value in the let binding, but that makes the code look a bit uglier.

http://stackoverflow.com/questions/3837801/how-to-change-root-logging-level-programmatically