### PR TITLE
Decouple JSON rendering implementation

### DIFF
--- a/ext/json/src/yada/json.clj
+++ b/ext/json/src/yada/json.clj
@@ -13,15 +13,29 @@
 
 ;; Outbound
 
+(defn render-map-impl
+  [m representation & [opts]]
+  (let [pretty (get-in representation [:media-type :parameters "pretty"])
+        cheshire-opts (get opts :yada.cheshire)
+        cheshire-opts (cond-> cheshire-opts
+                        pretty (assoc :pretty pretty))]
+    (str (json/encode m cheshire-opts) \newline)))
+
 (defmethod render-map "application/json"
   [m representation]
-  (let [pretty (get-in representation [:media-type :parameters "pretty"])]
-    (str (json/encode m {:pretty pretty}) \newline)))
+  (render-map-impl m representation))
+
+(defn render-seq-impl
+  [s representation & [opts]]
+  (let [pretty (get-in representation [:media-type :parameters "pretty"])
+        cheshire-opts (get opts :yada.cheshire)
+        cheshire-opts (cond-> cheshire-opts
+                        pretty (assoc :pretty pretty))]
+    (str (json/encode s cheshire-opts) \newline)))
 
 (defmethod render-seq "application/json"
   [s representation]
-  (let [pretty (get-in representation [:media-type :parameters "pretty"])]
-    (str (json/encode s {:pretty pretty}) \newline)))
+  (render-seq-impl s representation))
 
 (add-encoder
  java.lang.Exception


### PR DESCRIPTION
Decouple JSON rendering implementation from defmethod, so it can be easily overriden without copy/pasting too much.

My override now looks like this:

```
(defmethod render-map "application/json"
  [m representation]
  (yada-json/render-map-impl m representation {:yada.cheshire
                                               {:escape-non-ascii true}}))
```