### PR TITLE
Fixes omission of CORS header when allow-credentials is false

### DIFF
--- a/src/yada/security.clj
+++ b/src/yada/security.clj
@@ -161,7 +161,7 @@
         allow-origin
         (assoc-in [:response :headers "access-control-allow-origin"] allow-origin)
 
-        (:allow-credentials access-control)
+        (contains? access-control :allow-credentials)
         (assoc-in [:response :headers "access-control-allow-credentials"]
                   (to-header (:allow-credentials access-control)))
 

--- a/test/yada/cors_test.clj
+++ b/test/yada/cors_test.clj
@@ -56,3 +56,33 @@
                        (update :headers conj ["origin" "http://acme.ro"])))]
       (is (not (contains? (set (keys (:headers resp))) "access-control-allow-origin")))
       )))
+
+
+(deftest allow-credentials-test
+  (testing "Not setting allow credentials"
+    (let [res (resource {:methods {:get "Hello"}
+                         :access-control {:allow-origin "*"}})
+          h (handler res)
+          resp @(h (-> (mock/request :get "/")
+                       (update :headers conj ["origin" "http://localhost"])))]
+      (is (not (contains? (set (keys (:headers resp))) "access-control-allow-credentials")))))
+
+  (testing "Setting allow credentials to true"
+    (let [res (resource {:methods {:get "Hello"}
+                         :access-control {:allow-origin "*"
+                                          :allow-credentials true}})
+          h (handler res)
+          resp @(h (-> (mock/request :get "/")
+                       (update :headers conj ["origin" "http://localhost"])))]
+      (is (contains? (set (keys (:headers resp))) "access-control-allow-credentials"))
+      (is (= "true" (get-in resp [:headers "access-control-allow-credentials"])))))
+
+  (testing "Setting allow credentials to false"
+    (let [res (resource {:methods {:get "Hello"}
+                         :access-control {:allow-origin "*"
+                                          :allow-credentials false}})
+          h (handler res)
+          resp @(h (-> (mock/request :get "/")
+                       (update :headers conj ["origin" "http://localhost"])))]
+      (is (contains? (set (keys (:headers resp))) "access-control-allow-credentials"))
+      (is (= "false" (get-in resp [:headers "access-control-allow-credentials"]))))))


### PR DESCRIPTION
There's a bug in the processing of `{:access-control {:allow-credentials false}}`, which is addressed in this PR. Also added some tests to verify correct behaviour.