### PR TITLE
Revert skip-dir? in classpath resource

### DIFF
--- a/src/yada/resources/classpath_resource.clj
+++ b/src/yada/resources/classpath_resource.clj
@@ -9,29 +9,21 @@
 (defn new-classpath-resource
   "Create a new classpath resource that resolves requests with
    path info in the active classpath, relative to root-path.
-
    Optionally takes an options map with the following keys:
-
    * index-files - a collection of files to try if the path info
                    ends with /
-
    Example:
-
       (new-classpath-resource \"public\")
-
    would resolve index.html to public/index.html inside
    the active classpath (e.g. of the JAR that serves the resource).
-
    If used with bidi, the following route
-
      [\"\" (yada (new-classpath-resource
                 \"public\" {:index-files [\"index.html\"]}))]
-
    can be used to serve all files in public/ and fall back to
    index.html for URL paths like / or foo/."
   ([root-path]
    (new-classpath-resource root-path nil))
-  ([root-path {:keys [index-files skip-dir?]}]
+  ([root-path {:keys [index-files]}]
    (resource
     {:path-info?   true
      :methods      {}
@@ -42,12 +34,9 @@
              files     (if (= (last path-info) \/)
                          (map #(io/file root-path path %) index-files)
                          (list (io/file root-path path)))
-             remove-dirs (remove #(and % (.isDirectory (io/file %))))
-             transducers (cond-> [(map #(.getPath ^java.io.File %))
-                                  (map io/resource)]
-                           skip-dir? (conj remove-dirs)
-                           true (conj (drop-while nil?)))
-             res       (first (sequence (apply comp
-                                               transducers)
+             res       (first (sequence (comp
+                                         (map #(.getPath ^java.io.File %))
+                                         (map io/resource)
+                                         (drop-while nil?))
                                         files))]
          (as-resource res)))})))

--- a/test/yada/classpath_resource_test.clj
+++ b/test/yada/classpath_resource_test.clj
@@ -28,16 +28,13 @@
           body (:body response)]
       (is (= 200 (:status response)))
       (is (= body "File 1\n"))))
+  ;; I'm not sure if this a feature or a bug
   (testing "Directory from classpath is served"
     (let [resource (new-classpath-resource "static")
           response (get-path resource "/test")
           body (:body response)]
       (is (= 200 (:status response)))
       (is (= "file1.txt\nfile2.txt\n" body))))
-  (testing "Directory is not served when :skip-dir? is true"
-    (let [resource (new-classpath-resource "static" {:skip-dir? true})
-          response (get-path resource "/test2")]
-      (is (= 404 (:status response)))))
   (testing "Non-existent classpath resource yields 404"
     (let [resource (new-classpath-resource "static")
           response (get-path resource "/test/file3.txt")]


### PR DESCRIPTION
This didn't work correctly from an uberjar, so reverting. But at least we have got tests now. 