### PR TITLE
Bump core.async version

### DIFF
--- a/ext/async/project.clj
+++ b/ext/async/project.clj
@@ -8,4 +8,4 @@
             :url "https://opensource.org/licenses/MIT"}
   :pedantic? :abort
   :dependencies [[yada/core ~VERSION]
-                 [org.clojure/core.async "0.2.395"]])
+                 [org.clojure/core.async "0.3.443"]])


### PR DESCRIPTION
Fix core.async version. It's fallen out of sync with the main project.clj for dev, this fixes it for recent clojure versions again.