### PR TITLE
Fix set-version in-place edit for cross-platform compatibility

### DIFF
--- a/set-version
+++ b/set-version
@@ -1,5 +1,7 @@
-#!/bin/bash
-find . -name project.clj -exec sed -i "s/(def VERSION \".*\")/(def VERSION \"$1\")/g" '{}' \;
-sed -i "s/\[yada \".*\"\]/\[yada \"$1\"\]/g" doc/install.adoc
-sed -i "s/\[yada \".*\"\]/\[yada \"$1\"\]/g" README.md
-sed -i "s/\[yada\/lean \".*\"\]/\[yada\/lean \"$1\"\]/g" README.md
+#!/bin/sh
+ext="sedbak$$"
+find . -name project.clj -exec sed -i.$ext "s/(def VERSION \".*\")/(def VERSION \"$1\")/g" '{}' \;
+sed -i.$ext "s/\[yada \".*\"\]/\[yada \"$1\"\]/g" doc/install.adoc
+sed -i.$ext "s/\[yada \".*\"\]/\[yada \"$1\"\]/g" README.md
+sed -i.$ext "s/\[yada\/lean \".*\"\]/\[yada\/lean \"$1\"\]/g" README.md
+find . -name "*.$ext" -exec rm '{}' \;


### PR DESCRIPTION
This is a sucky situation as BSD sed and GNU sed are completely command-line incompatible with in-place editing without backup files. As `find -exec` is being used, even an expanded alias won't work.

So we use sed with backup files and remove them after. Fortunately the MacOS sed processing of `-i` will take a non-empty extension without spacing (as does GNU sed). Although `ex` or `ed` could be used, they aren't always installed on CI servers, but `sed` almost always is.

Also:
- use sh rather than bash whenever possible (MacOS defaults to Bash 3 not 4)
- if bash is really needed then shebang `#!/usr/bin/env bash` for those of us using Bash 4 with it ahead on the PATH
- uses a pid-specific backup file extension to mitigate accidental removal of non-temporary files

Tested on: macOS (Darwin), Alpine, Debian, Amazon Linux (RHEL6ish), Fedora
