### PR TITLE
Remove cider from project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -91,8 +91,6 @@
      :repl-options {:init-ns user
                     :welcome (println "Type (dev) to start")}
 
-     :plugins [[cider/cider-nrepl "0.14.0"]]
-
      :global-vars {*warn-on-reflection* true}
 
      :dependencies


### PR DESCRIPTION
This is not necessary to develop the project, and is just a developer utility that should be specified by developers in their own profiles.

Found this when tracking down a pedantic override of 14->15.