### PR TITLE
Return a 400 for requests missing form parameters

### DIFF
--- a/src/yada/interceptors.clj
+++ b/src/yada/interceptors.clj
@@ -183,8 +183,9 @@
             ctx)))
 
       ;; else
-      (if-let [body-schema (get-in ctx [:resource :methods (:method ctx) :parameters :body])]
-        (if (s/check body-schema nil)
+      (if-let [params-schema (or (get-in ctx [:resource :methods (:method ctx) :parameters :body])
+                                 (get-in ctx [:resource :methods (:method ctx) :parameters :form]))]
+        (if (s/check params-schema nil)
           (d/error-deferred
              (ex-info "No body present but body is expected for request."
                       {:status 400}))

--- a/test/yada/empty_body_test.clj
+++ b/test/yada/empty_body_test.clj
@@ -20,6 +20,18 @@
                     (mock/content-type "application/x-www-form-urlencoded"))]
         (is (= (:status @(handler req)) 400))))))
 
+(deftest no-form-parameters
+  (let [resource
+        (resource {:consumes [{:media-type #{"application/x-www-form-urlencoded"}}]
+                   :methods {:post {:parameters {:form {:foo sc/Int}}
+                                    :response (fn [ctx] "OK")}}})
+        handler (handler resource)]
+
+    (testing "no form body gives 400 issue #110"
+      (let [req (-> (mock/request :post "/" "")
+                    (mock/content-type "application/x-www-form-urlencoded"))]
+        (is (= (:status @(handler req)) 400))))))
+
 (deftest no-edn-body
   (let [resource
         (resource {:consumes [{:media-type #{"application/edn"}}]


### PR DESCRIPTION
empty and that didn't pass the :body resource schema. This commit
extends that support to also handle requests where the schema is defined
on the :form.

Relates to #110