### PR TITLE
Check referer header for same-origin? if origin not provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: clojure
-lein: lein2
 cache:
   directories:
     - $HOME/.m2

--- a/project.clj
+++ b/project.clj
@@ -42,6 +42,7 @@
 
      ;; Testing
      [ring/ring-mock "0.3.0"]
+     [juxt/iota "0.2.3"]
 
      ;; webjars testing needs this in the path
      [org.webjars/bootstrap "3.3.6"]

--- a/test/yada/util_test.clj
+++ b/test/yada/util_test.clj
@@ -3,7 +3,7 @@
 (ns yada.util-test
   (:require
    [clojure.test :refer :all]
-   [yada.util :refer (best best-by)]))
+   [yada.util :refer (best best-by same-origin?)]))
 
 (deftest best-test
   (is (= (best [3 2 3 nil 19]) 19))
@@ -12,3 +12,37 @@
 (deftest best-by-test
   (is (= (best-by first (comp - compare) [[3 9] [2 20] [3 -2] [nil 0] [19 10]]) [nil 0]))
   (is (= (best-by first (comp - compare) [[3 9] [2 20] [3 -2] [-2 0] [19 10]]) [-2 0])))
+
+(deftest same-origin?-test
+  (testing "same origin"
+    (testing "no origin header"
+      (is (same-origin? {:headers {"host" "localhost:6120"
+                                   "referer" "http://localhost:6120/my-app/path/"}
+                         :scheme :http})))
+    (testing "with origin header"
+      (is (same-origin? {:headers {"host" "localhost:6120"
+                                   "origin" "http://localhost:6120"
+                                   "referer" "http://localhost:6120/my-app/path/"}
+                         :scheme :http}))))
+  (testing "different origin"
+    (testing "different port"
+      (is (not (same-origin? {:headers {"host" "localhost:6120"
+                                        "referer" "http://localhost:6121/my-app/path/"}
+                              :scheme :http}))))
+    (testing "different scheme no origin header"
+      (is (not (same-origin? {:headers {"host" "localhost:6120"
+                                        "referer" "http://localhost:6120/my-app/path/"}
+                              :scheme :https}))))
+    (testing "different scheme with origin header"
+      (is (not (same-origin? {:headers {"host" "localhost:6120"
+                                        "origin" "http://localhost:6120"
+                                        "referer" "http://localhost:6120/my-app/path/"}
+                              :scheme :https}))))
+    (testing "different domain"
+      (is (not (same-origin? {:headers {"host" "example.com"
+                                        "origin" "http://example.net"
+                                        "referer" "http://example.net/my-app/path/"}
+                              :scheme :http}))))
+    (testing "no origin or referer"
+      (is (not (same-origin? {:headers {"host" "example.com"}
+                              :scheme :http}))))))


### PR DESCRIPTION
[Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=446344) and old IE versions don't provide an origin header when sending POSTs. If a POST request from the same origin returns a URI, Yada returns a 201 to these browsers, instead of a 303.

With this commit, Yada now checks the referer header to determine the request's origin if the origin header is not provided.