### PR TITLE
Use byte-streams 0.2.4-alpha4

### DIFF
--- a/bundles/lean/project.clj
+++ b/bundles/lean/project.clj
@@ -42,6 +42,7 @@
      [camel-snake-kebab "0.4.0"]
      [org.asciidoctor/asciidoctorj "1.6.0-alpha.3"]
      [markdown-clj "0.9.91"]
+     [juxt/iota "0.2.3" :scope "test"]
 
      ]
 

--- a/ext/aleph/project.clj
+++ b/ext/aleph/project.clj
@@ -7,5 +7,5 @@
   :license {:name "The MIT License"
             :url "https://opensource.org/licenses/MIT"}
   :pedantic? :abort
-  :dependencies [[aleph "0.4.3" :exclusions [io.aleph/dirigiste]]
+  :dependencies [[aleph "0.4.3" :exclusions [io.aleph/dirigiste byte-streams manifold riddley]]
                  [yada/core ~VERSION]])

--- a/project.clj
+++ b/project.clj
@@ -14,10 +14,10 @@
 ;;  :pedantic? :abort
 
   :dependencies
-  [[byte-streams "0.2.2"]
+  [[byte-streams "0.2.4-alpha4"]
    [clj-time "0.12.2"]
    [hiccup "1.0.5"]
-   [manifold "0.1.6"]
+   [manifold "0.1.7-alpha5"]
    [org.clojure/data.codec "0.1.0"]
    [org.clojure/tools.reader "1.0.0-beta4"]
    [potemkin "0.4.3"]


### PR DESCRIPTION
Use byte-streams 0.2.4-alpha4.

Byte-streams versions earlier than 0.2.4-alpha4 contains a decoding error. This is fixed in https://github.com/ztellman/byte-streams/commit/8075cdd8649251ea735a1932bb66a97812f7061b

For example the following fails in byte-streams 0.2.2, the version used in yada 1.2.10:

```!clojure
(test/is (= "å"
            (bs/to-string (ByteArrayInputStream. (.getBytes "å" StandardCharsets/UTF_8))
                          {:chunk-size 1})))
```
So this means that UTF characters that cross the chunk boundary (default 4096 bytes) may cause incorrect decoding.

This will also fix https://github.com/juxt/yada/issues/180

Referenced libraries were also upgraded / fixed so that `treelein install` and `test` works fine.

Regards.