### PR TITLE
Allow schemas to be passed to ring-swagger

### DIFF
--- a/src/yada/schema.clj
+++ b/src/yada/schema.clj
@@ -226,7 +226,8 @@ expressive short-hand descriptions."}
 
 (s/defschema MethodDocumentation
   (merge CommonDocumentation
-         {(s/optional-key :responses) {Statii (merge {:description String}
+         {(s/optional-key :responses) {Statii (merge {:description             String
+                                                      (s/optional-key :schema) s/Any}
                                                      NamespacedEntries)}}))
 
 (s/defschema MethodParameters


### PR DESCRIPTION
In the `:responses` section of a resource, `:description` was being passed
through untouched to ring-swagger, but didn't allow for the schema to be. This
is constrained by the normal output schema rules of ring-swagger, and has no
automatic validation, but is still useful.

```clojure
:responses {200 {:description "The normal response"
                 :schema [schema.core/Str]}}
```

solves https://github.com/juxt/yada/issues/197