### PR TITLE
Update webjars-locator 0.32 -> 0.34

### DIFF
--- a/ext/webjars/project.clj
+++ b/ext/webjars/project.clj
@@ -1,6 +1,6 @@
 ;; Copyright © 2014-2017, JUXT LTD.
 
-(def VERSION "1.2.11")
+(def VERSION "1.2.12")
 
 (defproject yada/webjars VERSION
   :description "Support for webjars"
@@ -8,4 +8,4 @@
             :url "https://opensource.org/licenses/MIT"}
   :pedantic? :abort
   :dependencies [[yada/core ~VERSION]
-                 [org.webjars/webjars-locator "0.32"]])
+                 [org.webjars/webjars-locator "0.34"]])

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
      [metosin/ring-swagger "0.22.12" :exclusions [org.clojure/clojure]]
      [org.webjars/swagger-ui "2.2.6"]
      [com.cognitect/transit-clj "0.8.297"]
-     [org.webjars/webjars-locator "0.32"]]
+     [org.webjars/webjars-locator "0.34"]]
 
     :source-paths
     [


### PR DESCRIPTION
This updates jackson-databind 2.3.3 -> 2.9.4, alleviating
https://nvd.nist.gov/vuln/detail/CVE-2017-7525.