### PR TITLE
Update buddy-sign 1.3.0 -> 2.2.0

### DIFF
--- a/ext/jwt/project.clj
+++ b/ext/jwt/project.clj
@@ -8,4 +8,4 @@
             :url "https://opensource.org/licenses/MIT"}
   :pedantic? :abort
   :dependencies [[yada/core ~VERSION]
-                 [buddy/buddy-sign "1.3.0"]])
+                 [buddy/buddy-sign "2.2.0"]])

--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,7 @@
      [org.clojure/core.async "0.3.442"]
      [cheshire "5.6.3"]
      [json-html "0.4.0" :exclusions [hiccups]]
-     [buddy/buddy-sign "1.3.0"]
+     [buddy/buddy-sign "2.2.0"]
      [commons-codec "1.10"]
      [metosin/ring-swagger "0.22.12" :exclusions [org.clojure/clojure]]
      [org.webjars/swagger-ui "2.2.6"]


### PR DESCRIPTION
This updates buddy-core 1.1.1 -> 1.4.0,
which updates org.bouncycastle/bcprov-jdk15on 1.55 -> 1.58,
alleviating CVE-2016-1000341.

See https://www.bouncycastle.org/releasenotes.html section 2.4.4, search
for CVE-2016-1000341.

This is a major version upgrade because of the following incompatible
change:
    https://github.com/funcool/buddy-sign/issues/39

Please verify this does not affect yada.