### PR TITLE
Don't throw an NPE when media-type string doesn't match pattern

### DIFF
--- a/test/yada/media_type_test.clj
+++ b/test/yada/media_type_test.clj
@@ -6,17 +6,21 @@
    [clojure.test :refer :all]
    [yada.media-type :refer :all]))
 
-(deftest media-type-test
-  (let [result {:name "text/html" :type "text" :subtype "html"
-                :parameters {"charset" "utf-8" "foo" "bar"}
-                :quality 1.0}]
-    (are [x y] (= (into {} (string->media-type x)) y)
-      "text/html" {:name "text/html" :type "text" :subtype "html" :parameters {} :quality 1.0}
-      "text/html;charset=utf-8" {:name "text/html" :type "text" :subtype "html" :parameters {"charset" "utf-8"} :quality 1.0}
-      "text/html;charset=utf-8;foo=bar" result
-      "text/html; charset=utf-8;foo=bar" result
-      "text/html; charset=utf-8;   \tfoo=bar" result
-      "image/png;q=0.5" {:name "image/png" :type "image" :subtype "png" :parameters {} :quality 0.5}
-      "*/*" {:name "*/*" :type "*" :subtype "*" :parameters {} :quality 1.0}
-      "*" {:name "*/*" :type "*" :subtype "*" :parameters {} :quality 1.0}
-      "*; charset=utf-8; q=0.5" {:name "*/*" :type "*" :subtype "*" :parameters {"charset" "utf-8"} :quality 0.5})))
+(deftest string->media-type-test
+  (testing "Invalid values return nil"
+    (are [x] (nil? (string->media-type x))
+      nil "" ";" "junk" "application/transit+json;, application/json;q=0.6"))
+  (testing "Valid values are correctly parsed"
+    (let [result {:name "text/html" :type "text" :subtype "html"
+                  :parameters {"charset" "utf-8" "foo" "bar"}
+                  :quality 1.0}]
+      (are [x y] (= (into {} (string->media-type x)) y)
+        "text/html" {:name "text/html" :type "text" :subtype "html" :parameters {} :quality 1.0}
+        "text/html;charset=utf-8" {:name "text/html" :type "text" :subtype "html" :parameters {"charset" "utf-8"} :quality 1.0}
+        "text/html;charset=utf-8;foo=bar" result
+        "text/html; charset=utf-8;foo=bar" result
+        "text/html; charset=utf-8;   \tfoo=bar" result
+        "image/png;q=0.5" {:name "image/png" :type "image" :subtype "png" :parameters {} :quality 0.5}
+        "*/*" {:name "*/*" :type "*" :subtype "*" :parameters {} :quality 1.0}
+        "*" {:name "*/*" :type "*" :subtype "*" :parameters {} :quality 1.0}
+        "*; charset=utf-8; q=0.5" {:name "*/*" :type "*" :subtype "*" :parameters {"charset" "utf-8"} :quality 0.5}))))


### PR DESCRIPTION
Fixes #204 and #222