### PR TITLE
Re-implement cookie auth

### DIFF
--- a/src/yada/security.clj
+++ b/src/yada/security.clj
@@ -19,11 +19,10 @@
       (let [[user password] (str/split (str cred) #":" 2)]
         (verify [user password])))))
 
-#_(defmethod verify :cookie [ctx {:keys [verify cookie]}]
-
-  (get-in ctx [:cookies cookie])
-
-  )
+(defmethod yada.security/verify :cookie [{cookie-map                                                                     :cookies
+                                          {{{{{cookie-name :cookie} :authorization} "default"} :realms} :access-control} :resource}
+                                         {verify-fn :verify}]
+  (verify-fn (get cookie-map cookie-name)))
 
 ;; A nil scheme is simply one that does not use any of the built-in
 ;; algorithms for IANA registered auth-schemes at


### PR DESCRIPTION
The docs say to create a resource with something like 
```
{:access-control
            {:scheme        :cookie
             :cookie        "my-cookie-name"
             :verify (fn [cookie])}}
```
but that fails schema validation. Also, cookie validation is currently commented out.

This method re-implements cookie auth by looking for the cookie name in the "default" realm under `:authorization` -> `:cookie`. 

Usage example:
```
{:access-control
                          {:scheme :cookie
                           :verify (fn [cookie]
                                     {:roles (when (= cookie "karen_wolf")
                                               #{:user})})
                           :authorization {:methods {:get :user}
                                           :cookie "brand"}}
                          :methods {:get {:produces #{"text/plain"}
                                          :response (fn [_ctx]
                                                      "I love cookies!")}}}
```

It does not support other realms apart from `default`, and it uses destructuring maybe a bit excessively ;-)

