### PR TITLE
Require yada.context in yada.cookies

### DIFF
--- a/src/yada/cookies.clj
+++ b/src/yada/cookies.clj
@@ -9,7 +9,8 @@
    [clojure.string :as str]
    [schema.coerce :as sc]
    [schema.core :as s]
-   [yada.syntax :as syn])
+   [yada.syntax :as syn]
+   yada.context)
   (:import
    (yada.context Context)))
 


### PR DESCRIPTION
https://danielcompton.net/2016/05/04/requiring-records-clojure-clojurescript

> Clojure dynamically generates the class for the record when that
namespace is required (ignoring AOT compiling). If your code never
requires the namespace that the record lives in, then it won’t be
created. This will cause ClassNotFoundException errors when you try to
import the class.

In the project this is an issue on, there is an explicit require of
yada.cookies which means that the ordering is different than the
coincidental order which works for most projects.