### PR TITLE
Add support for setting "SameSite" cookie attribute

### DIFF
--- a/doc/cookies.adoc
+++ b/doc/cookies.adoc
@@ -39,12 +39,13 @@ The following code has a `:get` method that returns a response that contains a `
 ----
 {:cookies
   {:session ; <1>
-    {:name "session"
-     :max-age 3600
-     :domain "example.com"
-     :path "/"
-     :secure true
-     :http-only true}}
+    {:name      "session"
+     :max-age   3600
+     :domain    "example.com"
+     :path      "/"
+     :secure    true
+     :http-only true
+     :same-site :lax}}
 
  :methods
   {:get

--- a/test/yada/create_response_test.clj
+++ b/test/yada/create_response_test.clj
@@ -19,5 +19,14 @@
                                  :http-only true}}}}
           response (:response (create-response ctx))]
       (is (=
-           ["foo=bar; Path=/abc; HttpOnly"]
+           ["foo=bar; HttpOnly; Path=/abc"]
+           (get-in response [:headers "set-cookie"])))))
+  (testing "that same-site cookie attribute works"
+    (let [ctx {:response
+               {:cookies {"foo" {:value "bar"
+                                 :path "/abc"
+                                 :same-site :lax}}}}
+          response (:response (create-response ctx))]
+      (is (=
+           ["foo=bar; Path=/abc; SameSite=lax"]
            (get-in response [:headers "set-cookie"]))))))


### PR DESCRIPTION
Deliberately only supports explicit values for `SameSite` even though the spec allows for setting it without a value (as it defaults to "strict").

I've sorted the list of cookie attributes. As far as I can tell, RFC6265 doesn't say anything about ordering of attributes, but it does say that "Although cookies are serialized linearly in the Cookie header, servers SHOULD NOT rely upon the serialization order".

Adds a test case as well.

Fixes #265 