### PR TITLE
Fix use of yada.context without require

### DIFF
--- a/src/yada/security.clj
+++ b/src/yada/security.clj
@@ -7,6 +7,7 @@
    [clojure.tools.logging :refer :all]
    [yada.authorization :as authorization]
    [yada.syntax :as syn]
+   yada.context
    [clojure.tools.logging :as log]
    [manifold.deferred :as d])
   (:import


### PR DESCRIPTION
Exception without this patch:

❯ lein run -m clojure.main -e "(require 'yada.security)"
Exception in thread "main" java.lang.ClassNotFoundException: yada.context.Context, compiling:(yada/security.clj:1:1)