### PR TITLE
Require manifold.stream before using Manifold's IEventSource

### DIFF
--- a/src/yada/resource.clj
+++ b/src/yada/resource.clj
@@ -5,6 +5,7 @@
    [hiccup.core :refer [html]]
    [schema.core :as s]
    [schema.utils :as su]
+   [manifold.stream]
    [yada.charset :as charset]
    [yada.context :refer [content-type]]
    [yada.schema :as ys]


### PR DESCRIPTION
The manifold.stream.core namespace needs to be required before referencing the interface.

Fixes #271