### PR TITLE
Use platform-specific file separator for classpath resources

### DIFF
--- a/src/yada/resources/classpath_resource.clj
+++ b/src/yada/resources/classpath_resource.clj
@@ -31,8 +31,7 @@
      (fn [ctx]
        (let [path-info (-> ctx :request :path-info)
              path      (str/replace path-info #"^/*" "")
-             files     (if (= (last path-info) \/)
-                         ;; FIXME This does not work on a Windows system (needs "/" instead of "\")
+             files     (if (= (last path-info) java.io.File/separator)
                          (map #(io/file root-path path %) index-files)
                          (list (io/file root-path path)))
              res       (first (sequence (comp


### PR DESCRIPTION
A minor update to resolve a comment in the code, that should improve compatibility with applications running on Windows filesystems.

May relate to #135 