### PR TITLE
Include exception cause in ex-info

### DIFF
--- a/src/yada/interceptors.clj
+++ b/src/yada/interceptors.clj
@@ -104,7 +104,7 @@
       (try
         (Long/parseLong len)
         (catch Exception e
-          (throw (ex-info "Malformed Content-Length" {:value len})))))))
+          (throw (ex-info "Malformed Content-Length" {:value len} e)))))))
 
 (defn get-properties
   [ctx]

--- a/src/yada/methods.clj
+++ b/src/yada/methods.clj
@@ -191,9 +191,11 @@
          (fn [e]
            (if (:status (ex-data e))
              (throw e)
-             (throw (ex-info "Error on GET" {:response (:response ctx)
-                                             :resource (type (:resource ctx))
-                                             :error e}))))))))
+             (throw (ex-info "Error on GET"
+                             {:response (:response ctx)
+                              :resource (type (:resource ctx))
+                              :error e}
+                             e))))))))
 
 ;; --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This hit me when I was trying to debug an exception that was getting thrown, but the stack trace stopped in yada, not in my own code where the original exception was being thrown.