### PR TITLE
handle a non-numeric status

### DIFF
--- a/src/yada/handler.clj
+++ b/src/yada/handler.clj
@@ -29,7 +29,7 @@
 
 (defn default-error-handler [e]
   (let [data (error-data e)]
-    (when-not (and (:status data) (< (:status data) 500))
+    (when-not (and (-> data :status number?) (< (:status data) 500))
       (when (instance? java.lang.Throwable e)
         (errorf e "Internal Error %s" (or (some-> data :status str) "")))
       (when data (errorf "ex-data: %s" data)))))


### PR DESCRIPTION
No idea where this error originated from, but got an annoying exception from our prod system:

```ERROR aleph.http.server: error in HTTP handler
  java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
  	at clojure.lang.Numbers.lt(Numbers.java:226)
  	at clojure.lang.Numbers.lt(Numbers.java:3841)
  	at yada.handler$default_error_handler.invokeStatic(handler.clj:35)```

Clearly somehow we have an error whose `:status` is a `String`, which the default error handler barfs on. I'd rather have it treat this as an error and report it, so I can debug the system.