### PR TITLE
Support setting max-age as a number and expand cookie test coverage

### DIFF
--- a/src/yada/cookies.clj
+++ b/src/yada/cookies.clj
@@ -63,7 +63,9 @@
                              (instance? java.time.Duration v) (tf/unparse (tf/formatters :rfc822) (time/from-date (java.util.Date/from (.plus (java.time.Instant/now) v))))
                              :else (str v)))
 
-               (format "; %s=%s" (set-cookie-attrs k) (name v)))))))
+               (format "; %s=%s" (set-cookie-attrs k) (if (keyword? v)
+                                                        (name v)
+                                                        v)))))))
 
 (defn encode-cookie
   [[k v]]

--- a/test/yada/cookies_test.clj
+++ b/test/yada/cookies_test.clj
@@ -2,7 +2,8 @@
   (:require
    [yada.cookies :as cookies]
    [clojure.test :refer :all]
-   [yada.yada :as yada]))
+   [yada.yada :as yada])
+  (:import (java.util Date)))
 
 (deftest cookie-test
   (let [cookies
@@ -56,4 +57,27 @@
          (= {:status 200,
              :headers
              {"set-cookie" ["session=; Expires=Thu, 01 Jan 1970 00:00:00 +0000"]},
-             :body nil} (update response :headers select-keys ["set-cookie"])))))))
+             :body nil} (update response :headers select-keys ["set-cookie"])))))
+
+    (testing "exercising all cookie attributes"
+      (let [response
+            (yada/response-for
+             {:cookies {:session {:name "session"
+                                  :max-age 3600
+                                  :expires (fn [_] (Date. 0))
+                                  :domain "example.com"
+                                  :path "/"
+                                  :secure true
+                                  :http-only true}}
+              :methods
+              {:get
+               {:produces "text/plain"
+                :response
+                (fn [ctx]
+                  (-> ctx
+                      (yada/set-cookie :session "xyz")))}}})]
+        (is
+         (= {:status 200
+             :headers {"set-cookie" ["session=xyz; Domain=example.com; Expires=Thu, 01 Jan 1970 00:00:00 +0000; HttpOnly; Max-Age=3600; Path=/; Secure"]}
+             :body nil}
+            (update response :headers select-keys ["set-cookie"])))))))


### PR DESCRIPTION
c69c003794d1f07336741dcd80aa7b8fa8ca5cdb added a call to `name` on the value of a cookie before encoding it. This worked on strings, symbols, and keywords, but doesn't work on numbers.

This commit fixes the bug, adds tests to exercise cookie attributes.