### PR TITLE
Fix and improve SameSite cookie support

### DIFF
--- a/src/yada/cookies.clj
+++ b/src/yada/cookies.clj
@@ -63,7 +63,9 @@
                              (instance? java.time.Duration v) (tf/unparse (tf/formatters :rfc822) (time/from-date (java.util.Date/from (.plus (java.time.Instant/now) v))))
                              :else (str v)))
 
-               (format "; %s=%s" (set-cookie-attrs k) (name v)))))))
+               (format "; %s=%s" (set-cookie-attrs k) (if (keyword? v)
+                                                        (name v)
+                                                        v)))))))
 
 (defn encode-cookie
   [[k v]]

--- a/src/yada/cookies.clj
+++ b/src/yada/cookies.clj
@@ -27,7 +27,7 @@
    (s/optional-key :http-only) s/Bool
    ;; technically this could also support a boolean which would default
    ;; to :strict, but let's be explicit about it
-   (s/optional-key :same-site) (s/enum :strict :lax)
+   (s/optional-key :same-site) (s/enum :strict :lax :none)
    (s/constrained s/Keyword namespace) s/Any})
 
 (s/defschema Cookies
@@ -62,6 +62,9 @@
                              (string? v) v
                              (instance? java.time.Duration v) (tf/unparse (tf/formatters :rfc822) (time/from-date (java.util.Date/from (.plus (java.time.Instant/now) v))))
                              :else (str v)))
+
+               :same-site
+               (format "; %s=%s" (set-cookie-attrs k) (str/capitalize (name v)))
 
                (format "; %s=%s" (set-cookie-attrs k) (if (keyword? v)
                                                         (name v)
@@ -116,6 +119,7 @@
                   :path (assoc acc :path v)
                   :secure (assoc acc :secure v)
                   :http-only (assoc acc :http-only v)
+                  :same-site (assoc acc :same-site v)
                   :name acc
                   (if (namespace k) (assoc acc k v) acc)))
               {}

--- a/src/yada/schema.clj
+++ b/src/yada/schema.clj
@@ -473,7 +473,8 @@ expressive short-hand descriptions."}
     (s/optional-key :domain) (s/pred #(re-matches syn/subdomain %))
     (s/optional-key :path) (s/pred #(re-matches syn/path %))
     (s/optional-key :secure) s/Bool
-    (s/optional-key :http-only) s/Bool}
+    (s/optional-key :http-only) s/Bool
+    (s/optional-key :same-site) (s/enum :strict :lax)}
    CookieConsumer
    NamespacedEntries))
 

--- a/test/yada/cookies_test.clj
+++ b/test/yada/cookies_test.clj
@@ -68,6 +68,7 @@
                                   :domain "example.com"
                                   :path "/"
                                   :secure true
+                                  :same-site :strict
                                   :http-only true}}
               :methods
               {:get
@@ -78,6 +79,6 @@
                       (yada/set-cookie :session "xyz")))}}})]
         (is
          (= {:status 200
-             :headers {"set-cookie" ["session=xyz; Domain=example.com; Expires=Thu, 01 Jan 1970 00:00:00 +0000; HttpOnly; Max-Age=3600; Path=/; Secure"]}
+             :headers {"set-cookie" ["session=xyz; Domain=example.com; Expires=Thu, 01 Jan 1970 00:00:00 +0000; HttpOnly; Max-Age=3600; Path=/; SameSite=Strict; Secure"]}
              :body nil}
             (update response :headers select-keys ["set-cookie"])))))))

--- a/test/yada/cookies_test.clj
+++ b/test/yada/cookies_test.clj
@@ -2,7 +2,8 @@
   (:require
    [yada.cookies :as cookies]
    [clojure.test :refer :all]
-   [yada.yada :as yada]))
+   [yada.yada :as yada])
+  (:import (java.util Date)))
 
 (deftest cookie-test
   (let [cookies
@@ -56,4 +57,27 @@
          (= {:status 200,
              :headers
              {"set-cookie" ["session=; Expires=Thu, 01 Jan 1970 00:00:00 +0000"]},
-             :body nil} (update response :headers select-keys ["set-cookie"])))))))
+             :body nil} (update response :headers select-keys ["set-cookie"])))))
+
+    (testing "exercising all cookie attributes"
+      (let [response
+            (yada/response-for
+             {:cookies {:session {:name "session"
+                                  :max-age 3600
+                                  :expires (fn [_] (Date. 0))
+                                  :domain "example.com"
+                                  :path "/"
+                                  :secure true
+                                  :http-only true}}
+              :methods
+              {:get
+               {:produces "text/plain"
+                :response
+                (fn [ctx]
+                  (-> ctx
+                      (yada/set-cookie :session "xyz")))}}})]
+        (is
+         (= {:status 200
+             :headers {"set-cookie" ["session=xyz; Domain=example.com; Expires=Thu, 01 Jan 1970 00:00:00 +0000; HttpOnly; Max-Age=3600; Path=/; Secure"]}
+             :body nil}
+            (update response :headers select-keys ["set-cookie"])))))))

--- a/test/yada/create_response_test.clj
+++ b/test/yada/create_response_test.clj
@@ -28,7 +28,7 @@
                                  :same-site :lax}}}}
           response (:response (create-response ctx))]
       (is (=
-           ["foo=bar; Path=/abc; SameSite=lax"]
+           ["foo=bar; Path=/abc; SameSite=Lax"]
            (get-in response [:headers "set-cookie"])))))
   (testing "that cookies with nil cause an exception"
     (let [ctx {:response


### PR DESCRIPTION
* Add support for SameSite=None cookie attributes (https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7)
* Capitalise SameSite attribute values
* Expand the resource schema to handle SameSite cookies
* Set same-site cookies when they are defined in the resource

This builds off #296, so you may want to review that first. I tried to create a [stacked PR](https://graysonkoonce.com/stacked-pull-requests-keeping-github-diffs-small/) for these two changes, but that only works if you are able to publish branches to the main repository.