### PR TITLE
Preserve cookies after authentication failure

### DIFF
--- a/src/yada/handler.clj
+++ b/src/yada/handler.clj
@@ -140,6 +140,9 @@
                               (contains? data :body)
                               (assoc-in [:response :body] (:body data))
 
+                              (contains? data :cookies)
+                              (assoc-in [:response :cookies] (:cookies data))
+
                               ;; This could override [:response :body]
                               (and (not (contains? data :body)) (not (:response custom-response)))
                               (standard-error status e rep)

--- a/src/yada/security.clj
+++ b/src/yada/security.clj
@@ -293,6 +293,14 @@
   (interpret-authorize-result [authorization ctx]
     (assoc ctx :authorization authorization)))
 
+(defn authorization-error-response [ctx]
+  ;; We will return a 401 or 403 normally in this response.
+  ;; We could return a 404 to keep the resource hidden.
+  ;; But we would still allow www-authenticate header in the error response        
+  (cond->
+      {:headers (select-keys (-> ctx :response :headers) ["www-authenticate"])}
+    (contains? (:response ctx) :cookies) (assoc :cookies (-> ctx :response :cookies))))
+
 (defn default-authorize
   "The default authorize succeeds if there are no authentication schemes
   declared, or if there are any credentials established. This is
@@ -316,7 +324,6 @@
 
     (let [authorization (call-fn-maybe (get-in ctx [:resource :authorization]) ctx)
           realms (get-in ctx [:resource :access-control :realms])]
-
       (cond
         (not realms)
         ;; New branch
@@ -331,14 +338,10 @@
                (if (:authentication ctx)
                  (throw
                   (ex-info "Forbidden"
-                           {:status 403 ; or 404 to keep the resource hidden
-                            ;; But allow www-authenticate header in error
-                            :headers (select-keys (-> ctx :response :headers) ["www-authenticate"])}))
+                           (assoc (authorization-error-response ctx) :status 403)))
                  (throw
                   (ex-info "No authorization provided"
-                           {:status 401 ; or 404 to keep the resource hidden
-                            ;; But allow www-authenticate header in error
-                            :headers (select-keys (-> ctx :response :headers) ["www-authenticate"])})))))))
+                           (assoc (authorization-error-response ctx) :status 401))))))))
 
         ;; This is the 'old' branch that is now deprecated and
         ;; sticking around to provide backwards compatibility.
@@ -353,14 +356,10 @@
                    (if credentials
                      (throw
                       (ex-info "Forbidden"
-                               {:status 403 ; or 404 to keep the resource hidden
-                                ;; But allow WWW-Authenticate header in error
-                                :headers (select-keys (-> ctx :response :headers) ["www-authenticate"])}))
+                               (assoc (authorization-error-response ctx) :status 403)))
                      (throw
                       (ex-info "No authorization provided"
-                               {:status 401 ; or 404 to keep the resource hidden
-                                ;; But allow WWW-Authenticate header in error
-                                :headers (select-keys (-> ctx :response :headers) ["www-authenticate"])})))
+                               (assoc (authorization-error-response ctx) :status 401))))
                    validation)))
              ctx))
          ctx (get-in ctx [:resource :access-control :realms]))

--- a/test/yada/test_util.clj
+++ b/test/yada/test_util.clj
@@ -14,6 +14,15 @@
 (defn to-string [s]
   (bs/convert s String))
 
+(defn submap?
+  "Is m1 a subset of m2?"
+  [m1 m2]
+  (if (and (map? m1) (map? m2))
+    (every? (fn [[k v]] (and (contains? m2 k)
+                             (submap? v (get m2 k))))
+            m1)
+    (= m1 m2)))
+
 (defmacro with-level
   "Sets the logging level for ns to level, while executing body."
   ;; See http://stackoverflow.com/questions/3837801/how-to-change-root-logging-level-programmatically


### PR DESCRIPTION
If cookies are unset by a cookie consumer (perhaps because they are
not valid), and authorization fails, the "set-cookie" header wasn't
being preserved in the error response. This means that there was no
easy way to unset a bad cookie.

This commit checks for cookies in the error handling code, and
preserves them if an exception was thrown.

It also adds a useful submap? function for testing part of the
response that we care about.