### PR TITLE
Fix (require) syntax for Method

### DIFF
--- a/doc/methods.adoc
+++ b/doc/methods.adoc
@@ -109,7 +109,7 @@ RFC.
 
 [source,clojure]
 ----
-(require '[yada.methods Method])
+(require '[yada.methods :refer [Method]])
 
 (deftype BrewMethod [])
 


### PR DESCRIPTION
The current sample code to require Method doesn't work because Method is a protocol.