### PR TITLE
Replace error-deferred for HEAD implementation

### DIFF
--- a/src/yada/handler.clj
+++ b/src/yada/handler.clj
@@ -152,7 +152,7 @@
                               (and (not (contains? data :body)) (:response custom-response))
                               (custom-error (:response custom-response) rep)
 
-                              true set-content-length)
+                              (not (= :head (:method ctx))) set-content-length)
 
                             (:error-interceptor-chain ctx)
 

--- a/src/yada/methods.clj
+++ b/src/yada/methods.clj
@@ -106,11 +106,10 @@
   (request [this ctx]
 
     (when-not (ctx/exists? ctx)
-      (d/error-deferred (ex-info "" {:status 404})))
+      (throw (ex-info "" {:status 404})))
 
     (when-not (get-in ctx [:response :produces])
-      (d/error-deferred
-       (ex-info "" {:status 406})))
+      (throw (ex-info "" {:status 406})))
 
     ;; HEAD is implemented without delegating to the resource.
 

--- a/test/yada/head_test.clj
+++ b/test/yada/head_test.clj
@@ -3,7 +3,7 @@
 (ns yada.head-test
   (:require
    [clojure.test :refer :all]
-   [ring.mock.request :refer [request]]
+   [ring.mock.request :as ring-mock]
    [yada.handler :refer [handler]]
    [yada.resource :refer [as-resource]]))
 
@@ -12,12 +12,28 @@
         h (handler (merge (as-resource resource)
                           {:produces {:media-type "text/plain"
                                       :charset "UTF-8"}}))
-        request (request :head "/")
+        request (ring-mock/request :head "/")
         response @(h request)
         headers (:headers response)]
 
     (is (= 200 (:status response)))
     (is (= "text/plain;charset=utf-8" (get headers "content-type")))
+
+    (is (nil? (get headers "content-length"))) ; see rfc7231.html#section-3.3
+
+    (is (nil? (:body response)))))
+
+(deftest head-content-type-not-unacceptable-test []
+  (let [h (handler (merge (as-resource "Hello World!")
+                          {:produces {:media-type "text/plain"
+                                      :charset "UTF-8"}}))
+        request (-> (ring-mock/request :head "/")
+                    (ring-mock/header :accept "text/foo"))
+        response @(h request)
+        headers (:headers response)]
+
+    (is (= 406 (:status response)))
+    (is (nil? (get headers "content-type")))
 
     (is (nil? (get headers "content-length"))) ; see rfc7231.html#section-3.3
 


### PR DESCRIPTION
Currently we're creating deferred errors which are never consumed (these log
exceptions when the next GC cycle runs), instead we can simply throw exceptions to be
caught be the outer deferred chain and handled in the normal catch block in
`yada.handler/handle-request-with-maybe-subresources`.

The only distinction from existing behaviour is that we will now return a 406 in
line with GET when we have no available representation for the HEAD, whereas
previously we would return a 200.

This aligns with the principle that the HEAD response should reflect the GET
other than providing a response body.

This PR should address #206.