### PR TITLE
Default to UTF-8 for form decoding

### DIFF
--- a/ext/swagger/src/yada/swagger_parameters.clj
+++ b/ext/swagger/src/yada/swagger_parameters.clj
@@ -102,7 +102,7 @@
       (or (:form schemas) (:body schemas))
       (let [fields (codec/form-decode
                     body-string
-                    (req/character-encoding (:request ctx)))
+                    (or (req/character-encoding (:request ctx)) "UTF-8"))
 
             coercer (sc/coercer
                      (or (:form schemas) (:body schemas))

--- a/src/yada/request_body.clj
+++ b/src/yada/request_body.clj
@@ -66,7 +66,7 @@
       (or (:form schemas) (:body schemas))
       (let [fields (codec/form-decode
                     body-string
-                    (req/character-encoding (:request ctx)))
+                    (or (req/character-encoding (:request ctx)) "UTF-8"))
 
             coercer (sc/coercer
                      (or (:form schemas) (:body schemas))


### PR DESCRIPTION
ring-codec 1.1.0 returns a {nil nil} map if you provide a nil character encoding. Previous versions defaulted to UTF-8.

This change ensures that "UTF-8" is provided to form-decode when newer versions of ring-codec are used.

More info: https://github.com/ring-clojure/ring-codec/issues/32.

I've made this as a PR to the 1.2 branch, but it should get forward ported as well.